### PR TITLE
Skip firebase deployment for PRs against live-site

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -1,6 +1,8 @@
 name: Deploy Preview to Firebase Hosting
 on:
   pull_request:
+    branches-ignore:
+      - live-site
 
 jobs:
   build_and_preview:


### PR DESCRIPTION
This disables the deploy preview action for PRs against live-site (as the staging deployment accomplishes this).