### PR TITLE
Replace api3.eth.link with api3.eth

### DIFF
--- a/docs/guides/dao-members/proposals.md
+++ b/docs/guides/dao-members/proposals.md
@@ -248,10 +248,8 @@ ERC20 token contract where `address` is the address of a _multisig_ wallet, you
 can
 [set a reverse record with the multisig](https://medium.com/the-ethereum-name-service/you-can-now-manage-ens-names-with-gnosis-safe-9ddcb7e6c4ac)<ExternalLinkImage/>
 to your ENS name. See Parameters in
-[this proposal](https://bafybeice5xg7dk6alljdkkkv4v65r6x5tgy3cpbxti4tlcd4yuyfzsz6mq.ipfs.dweb.link/#/history/secondary-31)<ExternalLinkImage/>
+[this proposal](https://api3.eth/#/history/secondary-31)<ExternalLinkImage/>
 for an example.
-
-<!-- The link above used to be https://api3.eth.link/#/history/secondary-6 -->
 
 ## Using IPFS for Proposals
 

--- a/libs/link-validator.js
+++ b/libs/link-validator.js
@@ -104,7 +104,7 @@ async function testLink(url, filePath, ignoreTimeout) {
     let arr = url.split('#');
     // Rule #1
     // Sometimes the anchor indicator (#) is in the
-    // path: https://api3.eth.link/#/history/secondary-6
+    // path: https://api3.eth/#/history/secondary-6
     // This is not an anchor, ignore it.
     if (url && url.indexOf('/#/') > -1) {
     }


### PR DESCRIPTION
See: https://api3workspace.slack.com/archives/C02ALA11APM/p1678106079904879?thread_ts=1678093121.848019&cid=C02ALA11APM

The idea is to be consistent with how to access the DAO dashboard and avoid suing `.eth.link` which is unsafe.