### PR TITLE
`fulfillmentGasLimit` changes move to `v0.12`

### DIFF
--- a/docs/reference/airnode/latest/chain-idiosyncrasies.md
+++ b/docs/reference/airnode/latest/chain-idiosyncrasies.md
@@ -42,20 +42,25 @@ manifests as the `maxFeePerGas` being set to less than the block
 ### Arbitrum
 
 Execution costs on Arbitrum are calculated slightly differently than Ethereum,
-which impacts the gas required to fulfill requests. To account for this, we
-recommend a minimum value of `5000000` for `fulfillmentGasLimit` when using both
-Arbitrum mainnet and testnet. Note that `fulfillmentGasLimit` is optional, so if
-you prefer not to specify it, Airnode will attempt to estimate the appropriate
-gas limit automatically. Read more about
+which impacts the gas required to fulfill requests. To account for this, it is
+recommended to use a minimum value of `5000000` for `fulfillmentGasLimit` when
+using both Arbitrum mainnet and testnet. Read more about
 [ArbGas<ExternalLinkImage/>](https://developer.offchainlabs.com/docs/arbgas) gas
 and fees.
+
+<!-- ADD BACK FOR v0.12 -->
+<!--Note that `fulfillmentGasLimit` is optional, so if
+you prefer not to specify it, Airnode will attempt to estimate the appropriate
+gas limit automatically.-->
 
 ### Metis
 
 On the Metis testnet Stardust, though not on the Metis mainnet Andromeda, it is
-recommended to use a `fulfillmentGasLimit` of at least `5000000`. If you prefer
-not to specify it, Airnode will attempt to estimate the appropriate gas limit
-automatically.
+recommended to use a `fulfillmentGasLimit` of at least `5000000`.
+
+<!-- ADD BACK FOR v0.12 -->
+<!--If unspecified, Airnode will attempt to estimate the appropriate gas limit
+automatically.-->
 
 ### Optimism
 

--- a/docs/reference/airnode/latest/deployment-files/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/config-json.md
@@ -221,11 +221,20 @@ for some considerations.
 
 #### `options.fulfillmentGasLimit`
 
+(required) - The maximum gas limit allowed when Airnode responds to a request,
+paid by the requester. If exceeded, the request is marked as failed and will not
+be repeated during Airnode's next run cycle.
+
+<!-- CHANGE FOR v0.12 -->
+<!--
+The above paragraph becomes as follow:
+
 (optional) - The maximum gas limit allowed when Airnode responds to a request,
 paid by the requester. If specified, this value will be used as the gas limit
 for the fulfillment. Note that if the gas cost exceeds the limit given, the
 request will be marked as failed and will not be retried during the next cycle.
 If not specified, Airnode will attempt to estimate the gas limit automatically.
+-->
 
 #### `options.withdrawalRemainder`
 


### PR DESCRIPTION
`fulfillmentGasLimit` has been commented out in `v0.11`. When `v0.12` is created uncomment it and remove the comments from `v0.11`.