### PR TITLE
`fulfillmentGasLimit` and minor doc set `/dev` changes

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -13,8 +13,8 @@ tags:
 # {{$frontmatter.title}}
 
 Use newer versions of Nodejs. Currently the builds on GitHub are using `v18`.
-Apple M1 users see the page [Rosetta, Nodejs, esbuild](/dev/rosetta.md) if you
-get an error.
+Mac users (Apple silicon) should see the page
+[Rosetta, Nodejs, esbuild](/dev/rosetta.md) if you get an error.
 
 ::: info Nodejs `v18`
 

--- a/docs/dev/rosetta.md
+++ b/docs/dev/rosetta.md
@@ -12,14 +12,14 @@ tags:
 
 # {{$frontmatter.title}}
 
-This page refers to M1 Macs that have implemented the use of Rosetta. It is best
-not to use Rosetta with the VitePress docs. While it may work it almost always
-results in longer builds and other processes. Other issues can arise such as the
-Rosetta platform error. This usually happens when Nodejs and NPM are installed
-using CLI running with Rosetta on, and NPM will install the wrong
-[esbuild](https://esbuild.github.io/getting-started/) package. It is best to use
-a version of Nodejs and NPM installed with its installer or install it using
-your CLI with Rosetta deactivated.
+This page refers to Apple silicon Macs that have implemented the use of Rosetta.
+It is best not to use Rosetta with the VitePress docs. While it may work it
+almost always results in longer builds and other processes. Other issues can
+arise such as the Rosetta platform error. This usually happens when Nodejs and
+NPM are installed using CLI running with Rosetta on, and NPM will install the
+wrong [esbuild](https://esbuild.github.io/getting-started/) package. It is best
+to use a version of Nodejs and NPM installed with its installer or install it
+using your CLI with Rosetta deactivated.
 
 ::: info Nodejs `v18`
 

--- a/docs/dev/ssr.md
+++ b/docs/dev/ssr.md
@@ -17,7 +17,7 @@ on for any domain related to the docs, then CloudFlare will minify the already
 minified build files from Firebase. This will result in the merging of pages
 visible to the reader.
 
-<img src="./assets/images/ssr-cloudflare.png" style="width:70%">
+<img src="./assets/images/ssr-cloudflare.png" style="width:70%;border:solid 1px gray">
 
 Because the docs are not using SSR and relying are on a CDN (Firebase), caching
 isn't necessary. The CDN is effectively a cache as the data is static. So

--- a/docs/reference/airnode/latest/chain-idiosyncrasies.md
+++ b/docs/reference/airnode/latest/chain-idiosyncrasies.md
@@ -42,20 +42,25 @@ manifests as the `maxFeePerGas` being set to less than the block
 ### Arbitrum
 
 Execution costs on Arbitrum are calculated slightly differently than Ethereum,
-which impacts the gas required to fulfill requests. To account for this, we
-recommend a minimum value of `5000000` for `fulfillmentGasLimit` when using both
-Arbitrum mainnet and testnet. Note that `fulfillmentGasLimit` is optional, so if
-you prefer not to specify it, Airnode will attempt to estimate the appropriate
-gas limit automatically. Read more about
+which impacts the gas required to fulfill requests. To account for this, it is
+recommended to use a minimum value of `5000000` for `fulfillmentGasLimit` when
+using both Arbitrum mainnet and testnet. Read more about
 [ArbGas<ExternalLinkImage/>](https://developer.offchainlabs.com/docs/arbgas) gas
 and fees.
+
+<!-- ADD BACK FOR v0.12 -->
+<!--Note that `fulfillmentGasLimit` is optional, so if
+you prefer not to specify it, Airnode will attempt to estimate the appropriate
+gas limit automatically.-->
 
 ### Metis
 
 On the Metis testnet Stardust, though not on the Metis mainnet Andromeda, it is
-recommended to use a `fulfillmentGasLimit` of at least `5000000`. If you prefer
-not to specify it, Airnode will attempt to estimate the appropriate gas limit
-automatically.
+recommended to use a `fulfillmentGasLimit` of at least `5000000`.
+
+<!-- ADD BACK FOR v0.12 -->
+<!--If unspecified, Airnode will attempt to estimate the appropriate gas limit
+automatically.-->
 
 ### Optimism
 

--- a/docs/reference/airnode/latest/deployment-files/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/config-json.md
@@ -221,11 +221,20 @@ for some considerations.
 
 #### `options.fulfillmentGasLimit`
 
+(required) - The maximum gas limit allowed when Airnode responds to a request,
+paid by the requester. If exceeded, the request is marked as failed and will not
+be repeated during Airnode's next run cycle.
+
+<!-- CHANGE FOR v0.12 -->
+<!--
+The above paragraph becomes as follow:
+
 (optional) - The maximum gas limit allowed when Airnode responds to a request,
 paid by the requester. If specified, this value will be used as the gas limit
 for the fulfillment. Note that if the gas cost exceeds the limit given, the
 request will be marked as failed and will not be retried during the next cycle.
 If not specified, Airnode will attempt to estimate the gas limit automatically.
+-->
 
 #### `options.withdrawalRemainder`
 


### PR DESCRIPTION
Comment out fulfillmentGasLimit changes that are now postponed to Airnode `v0.12`. Minor `/dev` docket changes