### PR TITLE
Improve providers language

### DIFF
--- a/docs/reference/airnode/latest/concepts/chain-providers.md
+++ b/docs/reference/airnode/latest/concepts/chain-providers.md
@@ -29,12 +29,14 @@ might use.
 - [Infura](https://infura.io)
 - [Alchemy](https://www.alchemy.com/)
 
-## One Chain: One Provider
+## One Provider
 
-As an example the `chains` field declares its use of _Sepolia_ blockchain with
-id 11155111. The `type` is set to _evm_ which is the only type currently
-supported by Airnode. It then applies an arbitrary name for the blockchain
-provider "infuraSepolia" in the `providers` array.
+In this example, the first (and only) element of the `chains` array specifies
+the _Sepolia_ blockchain via the `id` _11155111_. The `type` is set to _evm_,
+which is the only type currently supported by Airnode. The `providers` field
+specifies a single provider, the name of which is arbitrary and in this case is
+_infuraSepolia_. The inner object contains a single `url` field, the value of
+which is interpolated from `secrets.env`.
 
 ```json
 "chains": [
@@ -96,79 +98,10 @@ provider "infuraSepolia" in the `providers` array.
 ],
 ```
 
-## One Chain: Multiple Providers
+## Multiple Providers
 
-Multiple providers can be used per chain. Simply add another object to
-`providers`. In this case both blockchain providers will have the same chain
-`id` and `type`.
-
-```json
-"chains": [
-  {
-    "authorizers": {
-      "requesterEndpointAuthorizers": [
-        "0xf18c105D0375E80980e4EED829a4A68A539E6178"
-      ],
-      "crossChainRequesterAuthorizers": [],
-       "requesterAuthorizersWithErc721": [],
-       "crossChainRequesterAuthorizersWithErc721": []
-    },
-    "authorizations": {
-        "requesterEndpointAuthorizations": {}
-      },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
-    "id": "11155111",
-    "providers": {
-      "infuraSepolia": {
-        "url": "${INFURA_SEPOLIA_PROVIDER_URL}"
-      },
-      "alchemySepolia": {
-        "url": "${ALCHEMY_SEPOLIA_PROVIDER_URL}"
-      }
-    },
-    "type": "evm",
-    "options": {
-      "fulfillmentGasLimit": 500000,
-      "gasPriceOracle": [
-        {
-          "gasPriceStrategy": "latestBlockPercentileGasPrice",
-          "percentile": 60,
-          "minTransactionCount": 20,
-          "pastToCompareInBlocks": 20,
-          "maxDeviationMultiplier": 2,
-        },
-        {
-          "gasPriceStrategy": "providerRecommendedGasPrice",
-          "recommendedGasPriceMultiplier": 1.2,
-        },
-        {
-          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
-          "baseFeeMultiplier": 2,
-          "priorityFee": {
-            "value": 3.12,
-            "unit": "gwei",
-          }
-        },
-        {
-          "gasPriceStrategy": "constantGasPrice",
-          "gasPrice": {
-            "value": 10,
-            "unit": "gwei"
-          }
-        }
-      ],
-    },
-    "maxConcurrency": 100
-  }
-],
-```
-
-## Multiple Chains: Multiple Providers
-
-Not as complicated as it sounds. First create two or more chain objects were
-each has a unique `id` and `type` and a list of `providers` for each.
+Multiple providers can be used per chain, for example to improve resiliency.
+Simply add another uniquely named object to `providers` as shown below.
 
 ```json
 "chains": [
@@ -194,61 +127,6 @@ each has a unique `id` and `type` and a list of `providers` for each.
       },
       "alchemySepolia": {
         "url": "${ALCHEMY_SEPOLIA_PROVIDER_URL}"
-      }
-    },
-    "type": "evm",
-    "options": {
-      "fulfillmentGasLimit": 500000,
-      "gasPriceOracle": [
-        {
-          "gasPriceStrategy": "latestBlockPercentileGasPrice",
-          "percentile": 60,
-          "minTransactionCount": 20,
-          "pastToCompareInBlocks": 20,
-          "maxDeviationMultiplier": 2,
-        },
-        {
-          "gasPriceStrategy": "providerRecommendedGasPrice",
-          "recommendedGasPriceMultiplier": 1.2,
-        },
-        {
-          "gasPriceStrategy": "providerRecommendedEip1559GasPrice",
-          "baseFeeMultiplier": 2,
-          "priorityFee": {
-            "value": 3.12,
-            "unit": "gwei",
-          }
-        },
-        {
-          "gasPriceStrategy": "constantGasPrice",
-          "gasPrice": {
-            "value": 10,
-            "unit": "gwei"
-          }
-        }
-      ],
-    },
-    "maxConcurrency": 100
-  },
-  {
-    "authorizers": {
-      "requesterEndpointAuthorizers": [
-        "0xf18c105D0375E80980e4EED829a4A68A539E6178"
-      ],
-      "crossChainRequesterAuthorizers": [],
-       "requesterAuthorizersWithErc721": [],
-       "crossChainRequesterAuthorizersWithErc721": []
-    },
-    "authorizations": {
-        "requesterEndpointAuthorizations": {}
-      },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
-    "id": "11155111",
-    "providers": {
-      "infuraSepolia": {
-        "url": "${INFURA_SEPOLIA_PROVIDER_URL}"
       }
     },
     "type": "evm",

--- a/docs/reference/airnode/latest/deployment-files/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/config-json.md
@@ -204,10 +204,12 @@ Supported chains are listed under
 
 ### `providers`
 
-(required) - List of chain providers. Note that multiple can be used
-simultaneously. The Airnode deployment will expect to find the URLs of each of
-these chain providers in their respective `url` fields. It is generally
-recommended to provide `url` via interpolation from the `secrets.env` file.
+(required) - An object specifying one or more providers. Each provider object
+has an arbitrary name field and an object as a value. The value for the `url`
+field within this inner object specifies the url of the chain provider. It is
+generally recommended to provide the `url` value via interpolation from
+`secrets.env`. Also note that each provider name should be unique. For more see
+[Chain Providers](../concepts/chain-providers.md).
 
 ### `type`
 


### PR DESCRIPTION
Improves the language around `providers` and notes that provider names should be unique (the motivation comes from https://github.com/api3dao/airnode/issues/1709).

I've also deleted the "Multiple Chains: Multiple Providers" example because it had errors (used the same `id` and `providers` for both chains objects) and didn't add anything beyond the multiple providers section.