### PR TITLE
Describe enforced endpointId derivation scheme

### DIFF
--- a/docs/reference/airnode/latest/concepts/endpoint.md
+++ b/docs/reference/airnode/latest/concepts/endpoint.md
@@ -25,13 +25,12 @@ composed of [operations](/reference/ois/latest/specification.md#_5-2-operation),
 which represent individual functionalities that an API offers. OIS maps each API
 operation to an [endpoint](/reference/ois/latest/specification.md#_5-endpoints),
 which can be thought of as an Airnode operation. The endpoints that an Airnode
-will serve over the request–response protocol are listed under
-[trigge/reference/airnode/latest/deployment-files/config-json.md#triggers) of
-[config.json](/reference/airnode/latest/deployment-files/config-json.md).
+will serve over the request–response protocol are listed under triggers of
+[config.json](/reference/airnode/latest/deployment-files/config-json.md#triggers).
 
 ## `endpointId`
 
-`endpointId` identifies specific endpoints that an Airnode serves, and is
+`endpointId` identifies a specific endpoint that an Airnode serves, and is
 computed in JS (using ethers.js) as follows:
 
 ```js
@@ -49,7 +48,7 @@ endpoint ID.
 
 Note that this means that an `endpointId` is not unique, and two Airnodes can
 serve equivalent endpoints using the same ID (in fact, this is the desired
-outcome).This is not an issue, as requests are made with a `airnode` (Airnode's
+outcome). This is not an issue, as requests are made with a `airnode` (Airnode's
 `address`) and `endpointId` pair.
 
 This convention of determining an `endpointId` is not enforced at the

--- a/docs/reference/airnode/latest/deployment-files/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/config-json.md
@@ -610,7 +610,7 @@ as the
 [`endpointId`](/reference/airnode/latest/concepts/endpoint.md#endpointid), it
 will call the specified endpoint (`myOisTitle`-`myEndpointName`) with the
 parameters provided in the request to fulfill it. See the
-[endpoint id documentation](/reference/airnode/latest/concepts/endpoint.md#endpointid)
+[endpointId documentation](/reference/airnode/latest/concepts/endpoint.md#endpointid)
 for the default convention for deriving the `endpointId`.
 
 ### `rrp`

--- a/docs/reference/airnode/latest/packages/admin-cli.md
+++ b/docs/reference/airnode/latest/packages/admin-cli.md
@@ -642,11 +642,9 @@ npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about sal
 
 Derives an
 [endpointId](/reference/airnode/latest/deployment-files/config-json.md#triggers)
-from the OIS title and the endpoint's name. This command uses the convention
-described in the
-[triggers](/reference/airnode/latest/understand/configuring.md#triggers) section
-of the configuring airnode documentation. Add the `endpointId` to the
-config.json file (`triggers.rrp[n].endpointId`).
+from the OIS title and the endpoint's name as described in the
+[endpoint](/reference/airnode/latest/concepts/endpoint.md) documentation. Add
+the `endpointId` to the config.json file (`triggers.rrp[n].endpointId`).
 
 - `ois-title`: The title of the OIS from config.json (`ois.title`).
 - `endpoint-name`: The name of the endpoint from config.json

--- a/docs/reference/airnode/next/concepts/endpoint.md
+++ b/docs/reference/airnode/next/concepts/endpoint.md
@@ -25,14 +25,13 @@ composed of [operations](/reference/ois/latest/specification.md#_5-2-operation),
 which represent individual functionalities that an API offers. OIS maps each API
 operation to an [endpoint](/reference/ois/latest/specification.md#_5-endpoints),
 which can be thought of as an Airnode operation. The endpoints that an Airnode
-will serve over the request–response protocol are listed under
-[trigge/reference/airnode/next/deployment-files/config-json.md#triggers) of
-[config.json](/reference/airnode/next/deployment-files/config-json.md).
+will serve over the request–response protocol are listed under triggers of
+[config.json](/reference/airnode/next/deployment-files/config-json.md#triggers).
 
 ## `endpointId`
 
-`endpointId` identifies specific endpoints that an Airnode serves, and is
-computed in JS (using ethers.js) as follows:
+`endpointId` identifies a specific endpoint that an Airnode serves. Its
+derivation, shown below, is enforced by `airnode-validator`.
 
 ```js
 ethers.utils.keccak256(
@@ -49,13 +48,8 @@ endpoint ID.
 
 Note that this means that an `endpointId` is not unique, and two Airnodes can
 serve equivalent endpoints using the same ID (in fact, this is the desired
-outcome).This is not an issue, as requests are made with a `airnode` (Airnode's
+outcome). This is not an issue, as requests are made with a `airnode` (Airnode's
 `address`) and `endpointId` pair.
-
-This convention of determining an `endpointId` is not enforced at the
-protocol-level. For example, one could choose to generate an `endpointId`
-randomly, and as long as requesters use the correct `endpointId`, this will not
-be an issue.
 
 ## Authorizers
 

--- a/docs/reference/airnode/next/deployment-files/config-json.md
+++ b/docs/reference/airnode/next/deployment-files/config-json.md
@@ -607,8 +607,8 @@ and
 as the [`endpointId`](/reference/airnode/next/concepts/endpoint.md#endpointid),
 it will call the specified endpoint (`myOisTitle`-`myEndpointName`) with the
 parameters provided in the request to fulfill it. See the
-[endpoint id documentation](/reference/airnode/next/concepts/endpoint.md#endpointid)
-for the default convention for deriving the `endpointId`.
+[endpointId documentation](/reference/airnode/next/concepts/endpoint.md#endpointid)
+for `endpointId` derivation instructions.
 
 ### `rrp`
 

--- a/docs/reference/airnode/next/packages/admin-cli.md
+++ b/docs/reference/airnode/next/packages/admin-cli.md
@@ -641,11 +641,9 @@ npx @api3/airnode-admin derive-airnode-xpub --airnode-mnemonic "nature about sal
 
 Derives an
 [endpointId](/reference/airnode/next/deployment-files/config-json.md#triggers)
-from the OIS title and the endpoint's name. This command uses the convention
-described in the
-[triggers](/reference/airnode/next/understand/configuring.md#triggers) section
-of the configuring airnode documentation. Add the `endpointId` to the
-config.json file (`triggers.rrp[n].endpointId`).
+from the OIS title and the endpoint's name as described in the
+[endpoint](/reference/airnode/next/concepts/endpoint.md) documentation. Add the
+`endpointId` to the config.json file (`triggers.rrp[n].endpointId`).
 
 - `ois-title`: The title of the OIS from config.json (`ois.title`).
 - `endpoint-name`: The name of the endpoint from config.json


### PR DESCRIPTION
Closes #386. The primary goal of the PR is to describe how in v0.12 (`next/`) the `endpointId` will be enforced according to the described derivation scheme. I also addressed a handful of minor issues in `latest/` and `next/`.