### PR TITLE
20230425 legacy versions

### DIFF
--- a/archives/_components/explore/blog-posts.json
+++ b/archives/_components/explore/blog-posts.json
@@ -10,12 +10,6 @@
           "url": "https://medium.com/api3/apis-the-digital-glue-7ac87566e773"
         },
         {
-          "date": "Oct 11, 2020",
-          "dt": "2020-10-11",
-          "title": "The API Connectivity Problem",
-          "url": "https://medium.com/api3/the-api-connectivity-problem-bd7fa0420636"
-        },
-        {
           "date": "Oct 26, 2020",
           "dt": "2020-10-26",
           "title": "Where are the first-party oracles?",

--- a/docs/.vitepress/theme/components/SidebarHeader.vue
+++ b/docs/.vitepress/theme/components/SidebarHeader.vue
@@ -34,6 +34,7 @@ export default {
     isDark: undefined,
   }),
   mounted() {
+    console.log(Date.now(), window.navigator.userAgent);
     const { page } = useData();
     const { path } = useRoute();
     this.showVersions(path);

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -28,7 +28,6 @@ export default {
   // injects the slots
   Layout: Api3Layout,
   enhanceApp({ app }) {
-    console.log('API3 documentation loading...');
     app.component('VersionPicklist', VersionPicklist);
     app.component('SearchBtn', SearchBtn);
     app.component('SearchResults', SearchResults);

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -28,6 +28,7 @@ export default {
   // injects the slots
   Layout: Api3Layout,
   enhanceApp({ app }) {
+    console.log('API3 documentation loading...');
     app.component('VersionPicklist', VersionPicklist);
     app.component('SearchBtn', SearchBtn);
     app.component('SearchResults', SearchResults);

--- a/docs/.vitepress/versions-legacy.json
+++ b/docs/.vitepress/versions-legacy.json
@@ -1,0 +1,62 @@
+{
+  "versionsAirnode": [
+    {
+      "version": "v0.10",
+      "path": "https://old-docs.api3.org/airnode/v0.10/"
+    },
+    {
+      "version": "v0.9",
+      "path": "https://old-docs.api3.org/airnode/v0.9/"
+    },
+    {
+      "version": "v0.8",
+      "path": "https://old-docs.api3.org/airnode/v0.8/"
+    },
+    {
+      "version": "v0.7",
+      "path": "https://old-docs.api3.org/airnode/v0.7/"
+    },
+    {
+      "version": "v0.6",
+      "path": "https://old-docs.api3.org/airnode/v0.6/"
+    },
+    {
+      "version": "v0.5",
+      "path": "https://old-docs.api3.org/airnode/v0.5/"
+    },
+    {
+      "version": "v0.4",
+      "path": "https://old-docs.api3.org/airnode/v0.4/"
+    },
+    {
+      "version": "v0.3",
+      "path": "https://old-docs.api3.org/airnode/v0.3/"
+    },
+    {
+      "version": "v0.2",
+      "path": "https://old-docs.api3.org/airnode/v0.2/"
+    },
+    {
+      "version": "pre-alpha",
+      "path": "https://old-docs.api3.org/airnode/pre-alpha/"
+    }
+  ],
+  "versionsOIS": [
+    {
+      "version": "v1.4",
+      "path": "https://old-docs.api3.org/ois/v1.4/"
+    },
+    {
+      "version": "v1.2",
+      "path": "https://old-docs.api3.org/ois/v1.2/"
+    },
+    {
+      "version": "v1.1",
+      "path": "https://old-docs.api3.org/ois/v1.1/"
+    },
+    {
+      "version": "v1.0",
+      "path": "https://old-docs.api3.org/ois/v1.0/"
+    }
+  ]
+}

--- a/docs/_components/reference/VersionPicklist.vue
+++ b/docs/_components/reference/VersionPicklist.vue
@@ -69,6 +69,17 @@ export default {
         this.versions = [];
         this.versionsLegacy = [];
       }
+
+      // Alter the version array for PROD only.
+      // For PROD remove "/next" for Airnode and OIS
+      // The top of the versions array will always be the /next version
+      // if present at all.
+      if (
+        window.location.href.indexOf('localhost:5173') === -1 &&
+        this.versions[0].path.indexOf('/next') !== -1
+      ) {
+        this.versions.shift();
+      }
     },
     goToRoute() {
       if (this.path.indexOf('https://') === -1) {

--- a/docs/_components/reference/VersionPicklist.vue
+++ b/docs/_components/reference/VersionPicklist.vue
@@ -1,29 +1,36 @@
 <template>
-  <span v-if="versions.length > 1">
+  <span>
     <select @change="goToRoute" v-model="path" class="api3-version-select">
       <option v-for="vrs in versions" :key="vrs.path" :value="vrs.path">
         <span>{{ vrs.version }}</span>
         <!-- https://unicode-table.com/en/sets/arrow-symbols/#down-arrows -->
         <span v-if="path === vrs.path">&nbsp;&#9660;</span>
       </option>
+      <optgroup label="Legacy documentation">
+        <option v-for="vrs in versionsLegacy" :key="vrs.path" :value="vrs.path">
+          <span>{{ vrs.version }}</span>
+          <span v-if="path === vrs.path">&nbsp;&#9660;</span>
+        </option>
+      </optgroup>
     </select>
   </span>
-  <span v-else-if="staticVersion"> {{ staticVersion }}</span>
 </template>
 
 <script>
 import versionsArray from '../../.vitepress/versions';
+import versionsLegacyArray from '../../.vitepress/versions-legacy';
 import { useRouter, useData, useRoute } from 'vitepress';
 import { watch } from 'vue';
 
-//https://github.com/vuejs/vue-router/issues/3379
+// https://github.com/vuejs/vue-router/issues/3379
 
 export default {
   name: 'VersionPicklist',
   data: () => ({
     path: undefined,
-    versions: [], // Do not use undefined or the template wil error when loaded
-    staticVersion: undefined, // For Airnode  and OIS, if only one version put the version from frontmatter here
+    lastPath: undefined,
+    versions: [], // Do not use undefined or the template will error when loaded
+    versionsLegacy: [], // Same as above
     goRouterFunc: useRouter().go,
   }),
   mounted() {
@@ -33,7 +40,6 @@ export default {
       const p = currentPage.relativePath;
       this.parsePath('/' + p);
       this.setPickListData();
-      this.setStaticVersion(currentPage.frontmatter);
     });
 
     const { path } = useRoute();
@@ -41,7 +47,6 @@ export default {
 
     this.$nextTick(function () {
       this.setPickListData();
-      this.setStaticVersion(page._value.frontmatter); // passes the page frontmatter
     });
   },
   methods: {
@@ -49,48 +54,38 @@ export default {
       // Set this.path to the new path
       const arr = p.split('/');
       this.path = '/' + arr[1] + '/' + arr[2] + '/' + arr[3] + '/';
-    },
-    /**
-     * If Airnode or OIS only has one version then the static version from frontmatter
-     * must be displayed. /next is not considered a version released in PROD, only in DEV.
-     * @param {*} frontmatter
-     */
-    setStaticVersion(frontmatter) {
-      this.staticVersion = undefined;
-      // Only Airnode and OIS
-      if (
-        this.path.indexOf('/reference/airnode/') > -1 ||
-        this.path.indexOf('/reference/ois/') > -1
-      ) {
-        // Must have more than one version OR populate static version display
-        if (this.versions.length < 2) {
-          this.staticVersion = frontmatter.version;
-        }
-      }
+      this.lastPath = this.path;
     },
     setPickListData() {
       // Only for Airnode and OIS
       // slice() makes a copy of the original versions array
       if (this.path.indexOf('/reference/airnode/') > -1) {
         this.versions = versionsArray.versionsAirnode.slice();
+        this.versionsLegacy = versionsLegacyArray.versionsAirnode.slice();
       } else if (this.path.indexOf('/reference/ois/') > -1) {
         this.versions = versionsArray.versionsOIS.slice();
-      } else this.versions = [];
-
-      // Alter the version array for PROD only
-      // For PROD remove "/next" for Airnode and OIS
-      // The top of the versions array will always be the /next version.
-      // TEMP: For now OIS only has one version (this.versions.length > 1),
-      // so can remove the code (this.versions.length > 1) later
-      if (
-        window.location.href.indexOf('localhost:') === -1 &&
-        this.versions.length > 1
-      ) {
-        this.versions.shift();
+        this.versionsLegacy = versionsLegacyArray.versionsOIS.slice();
+      } else {
+        this.versions = [];
+        this.versionsLegacy = [];
       }
     },
     goToRoute() {
-      this.goRouterFunc(this.path);
+      if (this.path.indexOf('https://') === -1) {
+        this.lastPath = this.path;
+        this.goRouterFunc(this.path);
+      } else {
+        // Going to old docs
+        var a = document.createElement('a');
+        a.target = '_oldDocs';
+        a.href = this.path;
+        a.click();
+
+        // Set the path to lastPath
+        // Used to set the select list tot he last "new docs" version
+        // when going to the old docs.
+        this.path = this.lastPath;
+      }
     },
   },
 };

--- a/docs/_components/reference/VersionPicklist.vue
+++ b/docs/_components/reference/VersionPicklist.vue
@@ -76,6 +76,7 @@ export default {
       // if present at all.
       if (
         window.location.href.indexOf('localhost:5173') === -1 &&
+        this.versions.length > 0 &&
         this.versions[0].path.indexOf('/next') !== -1
       ) {
         this.versions.shift();
@@ -88,9 +89,13 @@ export default {
       } else {
         // Going to old docs
         var a = document.createElement('a');
-        // Be careful adding target back in. MacOS in DEV is fine
+        // Be careful adding target for MacOS,  in DEV it is fine,
         // but running a local build on localhost:8082 you get a pop-up blocked message.
-        // a.target = '_oldDocs';
+        // For other browser we want a new tab because the state of the newer docs is preserved
+        // in its tab.
+        if (window.navigator.userAgent.indexOf('Safari') === -1) {
+          a.target = '_oldDocs';
+        }
         a.href = this.path;
         a.click();
 

--- a/docs/_components/reference/VersionPicklist.vue
+++ b/docs/_components/reference/VersionPicklist.vue
@@ -77,7 +77,9 @@ export default {
       } else {
         // Going to old docs
         var a = document.createElement('a');
-        a.target = '_oldDocs';
+        // Be careful adding target back in. MacOS in DEV is fine
+        // but running a local build on localhost:8082 you get a pop-up blocked message.
+        // a.target = '_oldDocs';
         a.href = this.path;
         a.click();
 

--- a/docs/explore/airnode/pros-and-cons.md
+++ b/docs/explore/airnode/pros-and-cons.md
@@ -17,12 +17,11 @@ tags:
 # {{$frontmatter.title}}
 
 API3 embraces the ideology of a decentralized web and the power of open source.
-Furthermore it believes that the
-[oracle problem is ill-posed](https://medium.com/api3/the-api-connectivity-problem-bd7fa0420636)<ExternalLinkImage/>
-and instead, the problem to be solved is how to connect APIs to the blockchain.
-Airnode is a first-party oracle solution that addresses this problem. Like all
-design decisions, however, the advantages presented below have tradeoffs that
-should be understood.
+Furthermore it believes that the oracle problem is ill-posed and instead, the
+problem to be solved is how to connect APIs to the blockchain. Airnode is a
+first-party oracle solution that addresses this problem. Like all design
+decisions, however, the advantages presented below have tradeoffs that should be
+understood.
 
 ### Advantages
 

--- a/docs/explore/introduction/index.md
+++ b/docs/explore/introduction/index.md
@@ -78,8 +78,8 @@ to the lowest levels of the protocol.
 Additionally, existing oracle solutions fall short because they fail to make
 this distinction, resulting in inferior solutions that depend on third-party
 oracles and ecosystems that exclude API providers. As such, API3 believes the
-oracle problem is ill-posed, instead we are faced with an
-[API Connectivity Problem<ExternalLinkImage/>](https://medium.com/api3/the-api-connectivity-problem-bd7fa0420636).
+oracle problem is ill-posed, instead we are faced with an API Connectivity
+Problem.
 
 ## Airnode
 

--- a/docs/reference/airnode/latest/versions.md
+++ b/docs/reference/airnode/latest/versions.md
@@ -34,17 +34,17 @@ Prior to version `v0.11` there are several `v0.x` versions of Airnode. Their
 documentation is available at
 [https://old-docs.api3.org<ExternalLinkImage/>](https://old-docs.api3.org).
 
-|           |
-| --------- |
-| v0.10     |
-| v0.9      |
-| v0.8      |
-| v0.7      |
-| v0.6      |
-| v0.5      |
-| v0.4      |
-| v0.3      |
-| v0.2      |
-| pre-alpha |
+|                                                                               |
+| ----------------------------------------------------------------------------- |
+| [v0.10<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.10/)         |
+| [v0.9<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.9/)           |
+| [v0.8<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.8/)           |
+| [v0.7<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.7/)           |
+| [v0.6<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.6/)           |
+| [v0.5<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.5/)           |
+| [v0.4<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.4/)           |
+| [v0.3<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.3/)           |
+| [v0.2<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.2/)           |
+| [pre-alpha<ExternalLinkImage/>](https://old-docs.api3.org/airnode/pre-alpha/) |
 
 <FlexEndTag/>

--- a/docs/reference/airnode/next/versions.md
+++ b/docs/reference/airnode/next/versions.md
@@ -35,17 +35,17 @@ Prior to version `v0.11` there are several `v0.x` versions of Airnode. Their
 documentation is available at
 [https://old-docs.api3.org<ExternalLinkImage/>](https://old-docs.api3.org).
 
-|           |
-| --------- |
-| v0.10     |
-| v0.9      |
-| v0.8      |
-| v0.7      |
-| v0.6      |
-| v0.5      |
-| v0.4      |
-| v0.3      |
-| v0.2      |
-| pre-alpha |
+|                                                                               |
+| ----------------------------------------------------------------------------- |
+| [v0.10<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.10/)         |
+| [v0.9<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.9/)           |
+| [v0.8<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.8/)           |
+| [v0.7<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.7/)           |
+| [v0.6<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.6/)           |
+| [v0.5<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.5/)           |
+| [v0.4<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.4/)           |
+| [v0.3<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.3/)           |
+| [v0.2<ExternalLinkImage/>](https://old-docs.api3.org/airnode/v0.2/)           |
+| [pre-alpha<ExternalLinkImage/>](https://old-docs.api3.org/airnode/pre-alpha/) |
 
 <FlexEndTag/>


### PR DESCRIPTION
The older version of Airnode and OIS are now present in the versions menu for both in the sideBar header.