### PR TITLE
Clarify `sponsorWallet` language

### DIFF
--- a/docs/guides/airnode/calling-an-airnode/index.md
+++ b/docs/guides/airnode/calling-an-airnode/index.md
@@ -40,9 +40,9 @@ Make sure you're on a Testnet before trying to deploy the contracts on-chain!
 :::
 
 Given below is an example of a basic
-[Requester Contract](/reference/airnode/latest/concepts/requester.html) to
-request data from any Airnode. To follow along, you can open the following
-contract in Remix and try deploying your own Requester Contract.
+[Requester Contract](/reference/airnode/latest/concepts/requester.md) to request
+data from any Airnode. To follow along, you can open the following contract in
+Remix and try deploying your own Requester Contract.
 
 [Open in Remix<ExternalLinkImage/>](https://remix.ethereum.org/#url=https://github.com/vanshwassan/RemixContracts/blob/master/contracts/Requester.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
 
@@ -125,7 +125,7 @@ at runtime.
 ```
 
 Since the `makeRequest` function makes a
-[full request](/reference/airnode/latest/concepts/request.html#full-request), it
+[full request](/reference/airnode/latest/concepts/request.md#full-request), it
 needs the following parameters to pass on to `airnodeRrp.makeFullRequest`.
 
 - `airnode` and `endpointId`: As a pair, these uniquely identify the endpoint
@@ -135,7 +135,7 @@ needs the following parameters to pass on to `airnodeRrp.makeFullRequest`.
   address.
 
 - `sponsorWallet`: The
-  [sponsor wallet](/reference/airnode/latest/concepts/sponsor.html#sponsorwallet)
+  [sponsor wallet](/reference/airnode/latest/concepts/sponsor.md#sponsorwallet)
   address that the sponsor derived using the Airnode's address and extended
   public key.
 
@@ -143,9 +143,9 @@ needs the following parameters to pass on to `airnodeRrp.makeFullRequest`.
   contract and its function that is called upon the return of the request.
 
 - `parameters`: Specify the API parameters and any
-  [reserved parameters](/reference/ois/latest/reserved-parameters.html), these
+  [reserved parameters](/reference/ois/latest/reserved-parameters.md), these
   must be encoded. See
-  [Airnode ABI specifications](/reference/airnode/latest/specifications/airnode-abi.html)
+  [Airnode ABI specifications](/reference/airnode/latest/specifications/airnode-abi.md)
   for how these are encoded. In most, cases the `parameters` are encoded
   off-chain and passed to the requester which only forwards them. You can use
   the `@api3/airnode-abi` package to perform the encoding and decoding.
@@ -212,11 +212,11 @@ be calling the Coingecko Airnode to request the latest price of Ethereum.
 ### Sponsor the Requester
 
 The
-[Sponsor Wallet](/reference/airnode/latest/concepts/sponsor.html#sponsorwallet)
+[Sponsor Wallet](/reference/airnode/latest/concepts/sponsor.md#sponsorwallet)
 needs to be derived from the requester's contract address, the Airnode address,
 and the Airnode xpub. The wallet is used to pay gas costs of the transactions.
 The sponsor wallet must be derived using the command
-[derive-sponsor-wallet-address](/reference/airnode/latest/developers/requesters-sponsors.html#how-to-derive-a-sponsor-wallet)
+[derive-sponsor-wallet-address](/reference/airnode/latest/developers/requesters-sponsors.md#how-to-derive-a-sponsor-wallet)
 from the Admin CLI. Use the value of the sponsor wallet address that the command
 outputs while making the request. **This wallet needs to be funded.**
 
@@ -253,7 +253,7 @@ sponsor.
 ### Encoding parameters
 
 `parameters` specify the API and Reserved Parameters (see
-[Airnode ABI specifications](/reference/airnode/latest/specifications/airnode-abi.html)
+[Airnode ABI specifications](/reference/airnode/latest/specifications/airnode-abi.md)
 for how these are encoded). The parameters are required to be encoded in bytes32
 before you send it. Use the `@api3/airnode-abi` library to encode the parameters
 off-chain and then send it to the Requester.

--- a/docs/reference/airnode/latest/concepts/sponsor.md
+++ b/docs/reference/airnode/latest/concepts/sponsor.md
@@ -40,7 +40,7 @@ Making a request.
 1. The now "sponsored" requester makes a
    [request](/reference/airnode/latest/concepts/request.md) of an Airnode.
    Parameters passed to the Airnode include the `sponsorAddress` and the
-   `sponsorWalletAddress`.
+   `sponsorWallet` address.
 2. The Airnode verifies that the sponsor of the requester is the sponsor that
    derived the `sponsorWallet` associated with the Airnode.
 3. The Airnode uses the respective sponsor's `sponsorWallet` to fulfill the
@@ -54,10 +54,10 @@ How a requester refers to the sponsor.
    the requester is sponsored, and if so, emits the request event.
 
 2. Next Airnode derives the `sponsorWallet` address using the provided
-   `sponsorAddress`, then checks if this matches `sponsorWallet`. Airnode will
-   ignore the request if the two do not match. This is done this way because
-   deriving the `sponsorWallet` address from the `sponsorAddress` on-chain is
-   not feasible.
+   `sponsorAddress`, then checks if this matches the `sponsorWallet` address
+   provided in the request. Airnode will ignore the request if the two do not
+   match. This is done this way because deriving the `sponsorWallet` address
+   from the `sponsorAddress` on-chain is not feasible.
 
 ## sponsorAddress
 
@@ -142,7 +142,7 @@ m/44'/60'/0'/1/...
 ```
 
 Anyone can use the xpub that the Airnode has announced (through off-chain
-channels) and the sponsor's `sponsorAddress` to derive a `sponsorWalletAddress`
+channels) and the sponsor's `sponsorAddress` to derive a `sponsorWallet` address
 for a specific Airnode–sponsor pair. In other words, a sponsor can calculate the
 address of their respective sponsor wallet for an Airnode and have requesters
 use it to make requests right away.

--- a/docs/reference/airnode/latest/developers/requesters-sponsors.md
+++ b/docs/reference/airnode/latest/developers/requesters-sponsors.md
@@ -105,7 +105,7 @@ Airnodes regardless if they need to. There is no harm in this scenario.
   sponsorWallet for each Airnode was derived with the same `sponsorAddress` the
   sponsorWallets are different since they are derived using the airnode's xpub
   plus the `sponsorAddress`. The sponsor must fund both wallets separately using
-  the unique `sponsorWalletAddress` of the two sponsorWallets.
+  the unique `sponsorWallet` address of the two sponsorWallets.
 
 ### Things to Remember
 
@@ -183,7 +183,7 @@ npx @api3/airnode-admin sponsor-requester ^
 
 To use a particular Airnode you must _derive a sponsorWallet_. Once the
 sponsorWallet is created it must be funded using the public address
-(`sponsorWalletAddress`) returned by the command
+(`sponsorWallet` address) returned by the command
 `derive-sponsor-wallet-address`. Each Airnode keeps a separate list of
 individual sponsorWallets that can access the Airnode. Learn more about a
 [sponsorWallet](/reference/airnode/latest/concepts/sponsor.md#sponsorwallet).
@@ -201,7 +201,7 @@ transaction gas costs to do so.
   sponsoring a requester.
 
 The command `derive-sponsor-wallet-address` will return the public address
-(`sponsorWalletAddress`) of the sponsorWallet to be funded by the sponsor.
+(`sponsorWallet` address) of the sponsorWallet to be funded by the sponsor.
 
 ::: code-group
 
@@ -230,7 +230,7 @@ fulfill requests made by their requesters. However this does not cover the cost
 of API data that the Airnode serves, see
 [API Provider Fees](/reference/airnode/latest/developers/fees.md#api-provider-fees).
 
-If you forget the public address (`sponsorWalletAddress`) of the sponsorWallet
+If you forget the public address (`sponsorWallet` address) of the sponsorWallet
 simply run `derive-sponsor-wallet-address` again. Since the wallet already
 exists for the airnodeAddress/sponsorAddress pair it will just return the
 address.
@@ -242,13 +242,13 @@ address.
 During and after sponsoring requesters and deriving a sponsorWallet there are a
 few things to keep track of.
 
-| Item                   | Description                                                                                                                                                                                                                                                          |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sponsor's mnemonic     | The mnemonic from which the `sponsorAddress` was extracted.                                                                                                                                                                                                          |
-| sponsor address        | The public address of an account derived from a sponsor's mnemonic when sponsoring a requester. Record which `sponsorAddress` was used to create a sponsorWallet for each Airnode.                                                                                   |
-| sponsor wallet address | Record the `sponsorWalletAddress` of the sponsorWallet derived for an Airnode. For each Airnode you have derived a sponsorWallet, the Airnode keeps the private key and returns the public address (`sponsorWalletAddress`) which is used to fund the sponsorWallet. |
+| Item                   | Description                                                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| sponsor's mnemonic     | The mnemonic from which the `sponsorAddress` was extracted.                                                                                                                                                                                                            |
+| sponsor address        | The public address of an account derived from a sponsor's mnemonic when sponsoring a requester. Record which `sponsorAddress` was used to create a sponsorWallet for each Airnode.                                                                                     |
+| sponsor wallet address | Record the `sponsorWallet` address of the sponsorWallet derived for an Airnode. For each Airnode you have derived a sponsorWallet, the Airnode keeps the private key and returns the public address (`sponsorWallet` address) which is used to fund the sponsorWallet. |
 
-You can acquire the public address (`sponsorWalletAddress`) of a sponsorWallet
+You can acquire the public address (`sponsorWallet` address) of a sponsorWallet
 later, if you lose it, by running the command `derive-sponsor-wallet-address`
 again. Since the sponsorWallet was already created for the
 `sponsorAddress/airnodeAddress` pair, the command will only return the public

--- a/docs/reference/airnode/next/concepts/sponsor.md
+++ b/docs/reference/airnode/next/concepts/sponsor.md
@@ -40,7 +40,7 @@ Making a request.
 1. The now "sponsored" requester makes a
    [request](/reference/airnode/next/concepts/request.md) of an Airnode.
    Parameters passed to the Airnode include the `sponsorAddress` and the
-   `sponsorWalletAddress`.
+   `sponsorWallet` address.
 2. The Airnode verifies that the sponsor of the requester is the sponsor that
    derived the `sponsorWallet` associated with the Airnode.
 3. The Airnode uses the respective sponsor's `sponsorWallet` to fulfill the
@@ -54,10 +54,10 @@ How a requester refers to the sponsor.
    the requester is sponsored, and if so, emits the request event.
 
 2. Next Airnode derives the `sponsorWallet` address using the provided
-   `sponsorAddress`, then checks if this matches `sponsorWallet`. Airnode will
-   ignore the request if the two do not match. This is done this way because
-   deriving the `sponsorWallet` address from the `sponsorAddress` on-chain is
-   not feasible.
+   `sponsorAddress`, then checks if this matches `sponsorWallet` address
+   provided in the request. Airnode will ignore the request if the two do not
+   match. This is done this way because deriving the `sponsorWallet` address
+   from the `sponsorAddress` on-chain is not feasible.
 
 ## sponsorAddress
 
@@ -142,7 +142,7 @@ m/44'/60'/0'/1/...
 ```
 
 Anyone can use the xpub that the Airnode has announced (through off-chain
-channels) and the sponsor's `sponsorAddress` to derive a `sponsorWalletAddress`
+channels) and the sponsor's `sponsorAddress` to derive a `sponsorWallet` address
 for a specific Airnode–sponsor pair. In other words, a sponsor can calculate the
 address of their respective sponsor wallet for an Airnode and have requesters
 use it to make requests right away.

--- a/docs/reference/airnode/next/developers/requesters-sponsors.md
+++ b/docs/reference/airnode/next/developers/requesters-sponsors.md
@@ -105,7 +105,7 @@ Airnodes regardless if they need to. There is no harm in this scenario.
   sponsorWallet for each Airnode was derived with the same `sponsorAddress` the
   sponsorWallets are different since they are derived using the airnode's xpub
   plus the `sponsorAddress`. The sponsor must fund both wallets separately using
-  the unique `sponsorWalletAddress` of the two sponsorWallets.
+  the unique `sponsorWallet` address of the two sponsorWallets.
 
 ### Things to Remember
 
@@ -183,7 +183,7 @@ npx @api3/airnode-admin sponsor-requester ^
 
 To use a particular Airnode you must _derive a sponsorWallet_. Once the
 sponsorWallet is created it must be funded using the public address
-(`sponsorWalletAddress`) returned by the command
+(`sponsorWallet` address) returned by the command
 `derive-sponsor-wallet-address`. Each Airnode keeps a separate list of
 individual sponsorWallets that can access the Airnode. Learn more about a
 [sponsorWallet](/reference/airnode/next/concepts/sponsor.md#sponsorwallet).
@@ -201,7 +201,7 @@ transaction gas costs to do so.
   sponsoring a requester.
 
 The command `derive-sponsor-wallet-address` will return the public address
-(`sponsorWalletAddress`) of the sponsorWallet to be funded by the sponsor.
+(`sponsorWallet` address) of the sponsorWallet to be funded by the sponsor.
 
 ::: code-group
 
@@ -230,7 +230,7 @@ fulfill requests made by their requesters. However this does not cover the cost
 of API data that the Airnode serves, see
 [API Provider Fees](/reference/airnode/next/developers/fees.md#api-provider-fees).
 
-If you forget the public address (`sponsorWalletAddress`) of the sponsorWallet
+If you forget the public address (`sponsorWallet` address) of the sponsorWallet
 simply run `derive-sponsor-wallet-address` again. Since the wallet already
 exists for the airnodeAddress/sponsorAddress pair it will just return the
 address.
@@ -242,13 +242,13 @@ address.
 During and after sponsoring requesters and deriving a sponsorWallet there are a
 few things to keep track of.
 
-| Item                   | Description                                                                                                                                                                                                                                                          |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sponsor's mnemonic     | The mnemonic from which the `sponsorAddress` was extracted.                                                                                                                                                                                                          |
-| sponsor address        | The public address of an account derived from a sponsor's mnemonic when sponsoring a requester. Record which `sponsorAddress` was used to create a sponsorWallet for each Airnode.                                                                                   |
-| sponsor wallet address | Record the `sponsorWalletAddress` of the sponsorWallet derived for an Airnode. For each Airnode you have derived a sponsorWallet, the Airnode keeps the private key and returns the public address (`sponsorWalletAddress`) which is used to fund the sponsorWallet. |
+| Item                   | Description                                                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| sponsor's mnemonic     | The mnemonic from which the `sponsorAddress` was extracted.                                                                                                                                                                                                            |
+| sponsor address        | The public address of an account derived from a sponsor's mnemonic when sponsoring a requester. Record which `sponsorAddress` was used to create a sponsorWallet for each Airnode.                                                                                     |
+| sponsor wallet address | Record the `sponsorWallet` address of the sponsorWallet derived for an Airnode. For each Airnode you have derived a sponsorWallet, the Airnode keeps the private key and returns the public address (`sponsorWallet` address) which is used to fund the sponsorWallet. |
 
-You can acquire the public address (`sponsorWalletAddress`) of a sponsorWallet
+You can acquire the public address (`sponsorWallet` address) of a sponsorWallet
 later, if you lose it, by running the command `derive-sponsor-wallet-address`
 again. Since the sponsorWallet was already created for the
 `sponsorAddress/airnodeAddress` pair, the command will only return the public


### PR DESCRIPTION
Closes #454. This also renames `sponsorWalletAddress` to `sponsorWallet` address throughout as `sponsorWallet` is the parameter that AirnodeRrpV0 [expects](https://github.com/api3dao/airnode/blob/f49228a15f73aa8d21001bd305ae2d3f5180db59/packages/airnode-protocol/contracts/rrp/AirnodeRrpV0.sol#L66). This also updates a handful of internal `.html` links to `.md`.