### PR TITLE
Add landing page hero navigation links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,12 +15,24 @@ hero:
     - theme: brand
       text: Explore
       link: /explore/introduction/
+    - theme: brand
+      text: Guides
+      link: /guides/
+    - theme: brand
+      text: DAO Members
+      link: /explore/dao-members/
     - theme: alt
-      text: API3 on GitHub
-      link: https://github.com/api3dao
+      text: Airnode Reference
+      link: /reference/airnode/latest/understand/
     - theme: alt
-      text: Documentation Contributions
-      link: https://github.com/api3dao/vitepress-docs/
+      text: dAPIs Reference
+      link: /reference/dapis/understand/
+    - theme: alt
+      text: OIS Reference
+      link: /reference/ois/latest/
+    - theme: alt
+      text: QRNG Reference
+      link: /reference/qrng/
 ---
 
 <!--


### PR DESCRIPTION
The landing page hero would benefit from links to all of the most important starting points. I would also argue it does not need to include links to the GitHub repo as these are elsewhere and are not what we want to direct users to when landing on the docs.