### PR TITLE
Reorder Airnode Reference sidebar

### DIFF
--- a/docs/reference/airnode/latest/sidebar.js
+++ b/docs/reference/airnode/latest/sidebar.js
@@ -1,28 +1,5 @@
 module.exports = [
   {
-    text: '',
-
-    items: [
-      {
-        text: 'Contract Addresses',
-        link: '/reference/airnode/latest/',
-      },
-      { text: 'Versions', link: '/reference/airnode/latest/versions' },
-      {
-        text: 'Cloud Resources',
-        link: '/reference/airnode/latest/cloud-resources',
-      },
-      {
-        text: 'Chain Idiosyncrasies',
-        link: '/reference/airnode/latest/chain-idiosyncrasies',
-      },
-      {
-        text: 'Migration Guide',
-        link: '/reference/airnode/latest/migration',
-      },
-    ],
-  },
-  {
     text: 'Understanding Airnode',
     collapsed: false,
     items: [
@@ -69,6 +46,45 @@ module.exports = [
       {
         text: 'Monitoring Airnode',
         link: '/reference/airnode/latest/understand/monitor',
+      },
+    ],
+  },
+  {
+    text: 'Airnode for dApp Developers',
+    collapsed: false,
+    items: [
+      { text: 'Airnode RRP', link: '/reference/airnode/latest/developers/' },
+      {
+        text: 'Requesters and Sponsors',
+        link: '/reference/airnode/latest/developers/requesters-sponsors',
+      },
+      {
+        text: 'Using Templates (RRP)',
+        link: '/reference/airnode/latest/developers/using-templates',
+      },
+      { text: 'Fees', link: '/reference/airnode/latest/developers/fees' },
+    ],
+  },
+  {
+    text: 'Deployment References',
+    collapsed: false,
+    items: [
+      {
+        text: 'Contract Addresses',
+        link: '/reference/airnode/latest/',
+      },
+      { text: 'Versions', link: '/reference/airnode/latest/versions' },
+      {
+        text: 'Cloud Resources',
+        link: '/reference/airnode/latest/cloud-resources',
+      },
+      {
+        text: 'Chain Idiosyncrasies',
+        link: '/reference/airnode/latest/chain-idiosyncrasies',
+      },
+      {
+        text: 'Migration Guide',
+        link: '/reference/airnode/latest/migration',
       },
     ],
   },
@@ -252,22 +268,6 @@ module.exports = [
         text: 'Validator',
         link: '/reference/airnode/latest/packages/validator',
       },
-    ],
-  },
-  {
-    text: 'Airnode for dApp Developers',
-    collapsed: true,
-    items: [
-      { text: 'Airnode RRP', link: '/reference/airnode/latest/developers/' },
-      {
-        text: 'Requesters and Sponsors',
-        link: '/reference/airnode/latest/developers/requesters-sponsors',
-      },
-      {
-        text: 'Using Templates (RRP)',
-        link: '/reference/airnode/latest/developers/using-templates',
-      },
-      { text: 'Fees', link: '/reference/airnode/latest/developers/fees' },
     ],
   },
 ];

--- a/docs/reference/airnode/next/sidebar.js
+++ b/docs/reference/airnode/next/sidebar.js
@@ -1,28 +1,5 @@
 module.exports = [
   {
-    text: '',
-
-    items: [
-      {
-        text: 'Contract Addresses',
-        link: '/reference/airnode/next/',
-      },
-      { text: 'Versions', link: '/reference/airnode/next/versions' },
-      {
-        text: 'Cloud Resources',
-        link: '/reference/airnode/next/cloud-resources',
-      },
-      {
-        text: 'Chain Idiosyncrasies',
-        link: '/reference/airnode/next/chain-idiosyncrasies',
-      },
-      {
-        text: 'Migration Guide',
-        link: '/reference/airnode/next/migration',
-      },
-    ],
-  },
-  {
     text: 'Understanding Airnode',
     collapsed: false,
     items: [
@@ -69,6 +46,45 @@ module.exports = [
       {
         text: 'Monitoring Airnode',
         link: '/reference/airnode/next/understand/monitor',
+      },
+    ],
+  },
+  {
+    text: 'Airnode for dApp Developers',
+    collapsed: false,
+    items: [
+      { text: 'Airnode RRP', link: '/reference/airnode/next/developers/' },
+      {
+        text: 'Requesters and Sponsors',
+        link: '/reference/airnode/next/developers/requesters-sponsors',
+      },
+      {
+        text: 'Using Templates (RRP)',
+        link: '/reference/airnode/next/developers/using-templates',
+      },
+      { text: 'Fees', link: '/reference/airnode/next/developers/fees' },
+    ],
+  },
+  {
+    text: 'Deployment References',
+    collapsed: false,
+    items: [
+      {
+        text: 'Contract Addresses',
+        link: '/reference/airnode/next/',
+      },
+      { text: 'Versions', link: '/reference/airnode/next/versions' },
+      {
+        text: 'Cloud Resources',
+        link: '/reference/airnode/next/cloud-resources',
+      },
+      {
+        text: 'Chain Idiosyncrasies',
+        link: '/reference/airnode/next/chain-idiosyncrasies',
+      },
+      {
+        text: 'Migration Guide',
+        link: '/reference/airnode/next/migration',
       },
     ],
   },
@@ -252,22 +268,6 @@ module.exports = [
         text: 'Validator',
         link: '/reference/airnode/next/packages/validator',
       },
-    ],
-  },
-  {
-    text: 'Airnode for dApp Developers',
-    collapsed: true,
-    items: [
-      { text: 'Airnode RRP', link: '/reference/airnode/next/developers/' },
-      {
-        text: 'Requesters and Sponsors',
-        link: '/reference/airnode/next/developers/requesters-sponsors',
-      },
-      {
-        text: 'Using Templates (RRP)',
-        link: '/reference/airnode/next/developers/using-templates',
-      },
-      { text: 'Fees', link: '/reference/airnode/next/developers/fees' },
     ],
   },
 ];


### PR DESCRIPTION
@wkande I think this is a more user-friendly and relevant ordering of the Airnode Reference sidebar navigation, let me know what you think. Essesntially, it deprioritizes contract addresses and related deployment reference pages and promotes "Understanding Airnode" as well as "Airnode for dAPP Developers".