### PR TITLE
chore: add docs/.vitepress/cache to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 /archives
 
 # .vitepress
+/docs/.vitepress/cache
 /docs/.vitepress/dist
 /docs/.vitepress/public
 /docs/.vuepress/styles


### PR DESCRIPTION
If I run `yarn docs:dev` then commit changes and try to push, `prettier` will fail on files in the vitepress cache. This PR solves that issue by adding the cache to `.prettierignore`.