### PR TITLE
fix(deps): bump @api3/chains to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "axios:build": "node libs/axiosBuildScripts.js; yarn format;"
   },
   "devDependencies": {
-    "@api3/chains": "^2.1.0",
+    "@api3/chains": "^3.1.0",
     "axios": "^1.2.1",
     "colors": "^1.4.0",
     "ethers": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
     "@algolia/logger-common" "4.17.0"
     "@algolia/requester-common" "4.17.0"
 
-"@api3/chains@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@api3/chains/-/chains-2.1.0.tgz#67219e94e3301378a14ba81d50d4740e093d5678"
-  integrity sha512-u/YIE6aXsoHssSc1kir0Ws/12oYEIFPIMm5yDxC6TxL0upglasmYx0vrty40QVaksgsavva/CQNme+zwdJy4yA==
+"@api3/chains@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@api3/chains/-/chains-3.1.0.tgz#37ae1a6c3d5419616d26a0340364587cbb81df86"
+  integrity sha512-lXEL6Of+Kcesb9j8LfTelttQwwVgYKU3Em5C7uiKofr3mSsxw3X0oaMRiAZBIRlCD7tuNWCXJx4wGmRcyFj+uA==
   dependencies:
     zod "^3.21.4"
 


### PR DESCRIPTION
Closes #543. 

I ran ` yarn axios:build` after bumping the package, which resulted in no changes (as expected). I did receive the below warning, but that is only because boba-moonbeam (chain ID `1294`) has been removed since the latest Airnode version (v0.11), which is what the script uses as a reference (specifically, `references.json` file in `airnode-protocol`).

```
chainId: 1294 (undefined) was not found and has been omitted.
```