### PR TITLE
fix: update 0.11 instances to 0.12 in latest/ and next/

### DIFF
--- a/docs/reference/airnode/latest/deployment-files/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/config-json.md
@@ -347,7 +347,7 @@ An object containing general deployment parameters of an Airnode.
 ```json
 // nodeSettings
 {
-  "nodeVersion": "0.11.0",
+  "nodeVersion": "0.12.0",
   "cloudProvider": {
     "type": "gcp",
     "region": "us-east1",

--- a/docs/reference/airnode/latest/deployment-files/examples/config-cloud.json
+++ b/docs/reference/airnode/latest/deployment-files/examples/config-cloud.json
@@ -71,7 +71,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/reference/airnode/latest/deployment-files/examples/config-local.json
+++ b/docs/reference/airnode/latest/deployment-files/examples/config-local.json
@@ -59,7 +59,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/reference/airnode/latest/deployment-files/receipt-json.md
+++ b/docs/reference/airnode/latest/deployment-files/receipt-json.md
@@ -53,7 +53,7 @@ not generated for client deployments (deploying to a Docker container).
       "disableConcurrencyReservations": false
     },
     "stage": "starter-example",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true
@@ -75,7 +75,7 @@ not generated for client deployments (deploying to a Docker container).
       "projectId": "api3-753118"
     },
     "stage": "dev",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true

--- a/docs/reference/airnode/latest/deployment-files/templates/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/templates/config-json.md
@@ -138,7 +138,7 @@ as a reference while building a config.json file.
      },
     "logFormat": "json",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "<FILL_*>"
   },
   "triggers": {

--- a/docs/reference/airnode/latest/developers/verify-airnode-addresses.md
+++ b/docs/reference/airnode/latest/developers/verify-airnode-addresses.md
@@ -2,9 +2,9 @@
 title: Verify Airnode Addresses
 sidebarHeader: Reference
 sidebarSubHeader: Airnode
-pageHeader: Reference → Airnode → v0.11 → Verify Airnode Addresses
+pageHeader: Reference → Airnode → v0.12 → Verify Airnode Addresses
 path: /reference/airnode/latest/developers/verify-airnode-addresses.html
-version: v0.11
+version: v0.12
 outline: deep
 tags:
 ---

--- a/docs/reference/airnode/latest/docker/admin-cli-image.md
+++ b/docs/reference/airnode/latest/docker/admin-cli-image.md
@@ -49,7 +49,7 @@ npx @api3/airnode-admin get-sponsor-status \
   --requester-address 0x2c2e12...
 
 # Docker
-docker run api3/airnode-admin:0.11.0 get-sponsor-status \
+docker run api3/airnode-admin:0.12.0 get-sponsor-status \
   --provider-url https://eth-goerli.gateway.pokt.network/v1/lb/<APP_ID> \
   --sponsor-address 0x9Ec6C4... \
   --requester-address 0x2c2e12...

--- a/docs/reference/airnode/latest/docker/client-image.md
+++ b/docs/reference/airnode/latest/docker/client-image.md
@@ -86,21 +86,21 @@ Use the following command to run Airnode:
 docker run \
   --volume $(pwd):/app/config \
   --name airnode \
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 ```powershell [Windows PowerShell]
 docker run  \
   --volume $(pwd):/app/config \
   --name airnode \
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 ```batch [Windows]
 docker run  ^
   --volume %cd%:/app/config ^
   --name airnode ^
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 :::

--- a/docs/reference/airnode/latest/docker/deployer-image.md
+++ b/docs/reference/airnode/latest/docker/deployer-image.md
@@ -106,14 +106,14 @@ some deployment information and is used to remove the Airnode.
 docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 :::
@@ -145,7 +145,7 @@ Use the following example to avoid the automatic removal of the Airnode.
 docker run -it --rm \
 -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
 -v "$(pwd):/app/config" \
-api3/airnode-deployer:0.11.0 deploy --auto-remove false
+api3/airnode-deployer:0.12.0 deploy --auto-remove false
 ```
 
 ### `list`
@@ -162,14 +162,14 @@ and/or `gcp.json` (for GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 list
+  api3/airnode-deployer:0.12.0 list
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 list
+  api3/airnode-deployer:0.12.0 list
 ```
 
 :::
@@ -183,14 +183,14 @@ just the cloud providers you want the deployer to list from.
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 list --cloud-providers aws
+  api3/airnode-deployer:0.12.0 list --cloud-providers aws
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 list --cloud-providers aws
+  api3/airnode-deployer:0.12.0 list --cloud-providers aws
 ```
 
 :::
@@ -211,14 +211,14 @@ run correctly: `aws.env` (for AWS) and/or `gcp.json` (for GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 info aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 info aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 info aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 info aws2c6ef2b3
 ```
 
 :::
@@ -242,14 +242,14 @@ version using its configuration. Check this with the
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 rollback aws2c6ef2b3 3580a278
+  api3/airnode-deployer:0.12.0 rollback aws2c6ef2b3 3580a278
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 rollback aws2c6ef2b3 3580a278
+  api3/airnode-deployer:0.12.0 rollback aws2c6ef2b3 3580a278
 ```
 
 :::
@@ -279,14 +279,14 @@ GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 fetch-files aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 fetch-files aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 fetch-files aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 fetch-files aws2c6ef2b3
 ```
 
 :::
@@ -309,14 +309,14 @@ the recommended way to remove a deployment, but an alternative is the
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 remove aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 remove aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 remove aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 remove aws2c6ef2b3
 ```
 
 :::
@@ -335,14 +335,14 @@ are needed for the command to run correctly: `aws.env` (for AWS) or `gcp.json`
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 remove-with-receipt
+  api3/airnode-deployer:0.12.0 remove-with-receipt
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 remove-with-receipt
+  api3/airnode-deployer:0.12.0 remove-with-receipt
 ```
 
 :::

--- a/docs/reference/airnode/latest/packages/admin-cli.md
+++ b/docs/reference/airnode/latest/packages/admin-cli.md
@@ -105,13 +105,13 @@ npx @api3/airnode-admin $COMMAND --help
 Use the Admin CLI docker image as an alternative to `npx`:
 
 ```sh
-docker run api3/airnode-admin:0.11.0 --help
+docker run api3/airnode-admin:0.12.0 --help
 ```
 
 View the parameters of a command:
 
 ```sh
-docker run api3/airnode-admin:0.11.0 $COMMAND --help
+docker run api3/airnode-admin:0.12.0 $COMMAND --help
 ```
 
 ## SDK

--- a/docs/reference/airnode/latest/understand/configuring.md
+++ b/docs/reference/airnode/latest/understand/configuring.md
@@ -232,7 +232,7 @@ The `nodeSettings` field holds node-specific (Airnode) configuration parameters.
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
 ```

--- a/docs/reference/airnode/latest/understand/deploying.md
+++ b/docs/reference/airnode/latest/understand/deploying.md
@@ -101,14 +101,14 @@ should the need arise.
 docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 :::
@@ -134,7 +134,7 @@ deployment was successful or not.
       "disableConcurrencyReservations": false
     },
     "stage": "dev",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true

--- a/docs/reference/airnode/latest/understand/heartbeat.md
+++ b/docs/reference/airnode/latest/understand/heartbeat.md
@@ -68,7 +68,7 @@ Turn on the optional heartbeat functionality by setting all fields in the
        },
       "logFormat": "json",
       "logLevel": "INFO",
-      "nodeVersion": "0.11.0",
+      "nodeVersion": "0.12.0",
       "stage": "testnet",
   }
 }

--- a/docs/reference/airnode/next/deployment-files/config-json.md
+++ b/docs/reference/airnode/next/deployment-files/config-json.md
@@ -347,7 +347,7 @@ An object containing general deployment parameters of an Airnode.
 ```json
 // nodeSettings
 {
-  "nodeVersion": "0.11.0",
+  "nodeVersion": "0.12.0",
   "cloudProvider": {
     "type": "gcp",
     "region": "us-east1",

--- a/docs/reference/airnode/next/deployment-files/examples/config-cloud.json
+++ b/docs/reference/airnode/next/deployment-files/examples/config-cloud.json
@@ -71,7 +71,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/reference/airnode/next/deployment-files/examples/config-local.json
+++ b/docs/reference/airnode/next/deployment-files/examples/config-local.json
@@ -59,7 +59,7 @@
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
   "triggers": {

--- a/docs/reference/airnode/next/deployment-files/receipt-json.md
+++ b/docs/reference/airnode/next/deployment-files/receipt-json.md
@@ -53,7 +53,7 @@ not generated for client deployments (deploying to a Docker container).
       "disableConcurrencyReservations": false
     },
     "stage": "starter-example",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true
@@ -75,7 +75,7 @@ not generated for client deployments (deploying to a Docker container).
       "projectId": "api3-753118"
     },
     "stage": "dev",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true

--- a/docs/reference/airnode/next/deployment-files/templates/config-json.md
+++ b/docs/reference/airnode/next/deployment-files/templates/config-json.md
@@ -138,7 +138,7 @@ as a reference while building a config.json file.
      },
     "logFormat": "json",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "<FILL_*>"
   },
   "triggers": {

--- a/docs/reference/airnode/next/developers/verify-airnode-addresses.md
+++ b/docs/reference/airnode/next/developers/verify-airnode-addresses.md
@@ -2,9 +2,9 @@
 title: Verify Airnode Addresses
 sidebarHeader: Reference
 sidebarSubHeader: Airnode
-pageHeader: Reference → Airnode → v0.11 → Verify Airnode Addresses
+pageHeader: Reference → Airnode → v0.12 → Verify Airnode Addresses
 path: /reference/airnode/next/developers/verify-airnode-addresses.html
-version: v0.11
+version: v0.12
 outline: deep
 tags:
 ---

--- a/docs/reference/airnode/next/docker/admin-cli-image.md
+++ b/docs/reference/airnode/next/docker/admin-cli-image.md
@@ -49,7 +49,7 @@ npx @api3/airnode-admin get-sponsor-status \
   --requester-address 0x2c2e12...
 
 # Docker
-docker run api3/airnode-admin:0.11.0 get-sponsor-status \
+docker run api3/airnode-admin:0.12.0 get-sponsor-status \
   --provider-url https://eth-goerli.gateway.pokt.network/v1/lb/<APP_ID> \
   --sponsor-address 0x9Ec6C4... \
   --requester-address 0x2c2e12...

--- a/docs/reference/airnode/next/docker/client-image.md
+++ b/docs/reference/airnode/next/docker/client-image.md
@@ -86,21 +86,21 @@ Use the following command to run Airnode:
 docker run \
   --volume $(pwd):/app/config \
   --name airnode \
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 ```powershell [Windows PowerShell]
 docker run  \
   --volume $(pwd):/app/config \
   --name airnode \
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 ```batch [Windows]
 docker run  ^
   --volume %cd%:/app/config ^
   --name airnode ^
-  api3/airnode-client:0.11.0
+  api3/airnode-client:0.12.0
 ```
 
 :::

--- a/docs/reference/airnode/next/docker/deployer-image.md
+++ b/docs/reference/airnode/next/docker/deployer-image.md
@@ -106,14 +106,14 @@ some deployment information and is used to remove the Airnode.
 docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 :::
@@ -145,7 +145,7 @@ Use the following example to avoid the automatic removal of the Airnode.
 docker run -it --rm \
 -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
 -v "$(pwd):/app/config" \
-api3/airnode-deployer:0.11.0 deploy --auto-remove false
+api3/airnode-deployer:0.12.0 deploy --auto-remove false
 ```
 
 ### `list`
@@ -162,14 +162,14 @@ and/or `gcp.json` (for GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 list
+  api3/airnode-deployer:0.12.0 list
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 list
+  api3/airnode-deployer:0.12.0 list
 ```
 
 :::
@@ -183,14 +183,14 @@ just the cloud providers you want the deployer to list from.
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 list --cloud-providers aws
+  api3/airnode-deployer:0.12.0 list --cloud-providers aws
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 list --cloud-providers aws
+  api3/airnode-deployer:0.12.0 list --cloud-providers aws
 ```
 
 :::
@@ -211,14 +211,14 @@ run correctly: `aws.env` (for AWS) and/or `gcp.json` (for GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 info aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 info aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 info aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 info aws2c6ef2b3
 ```
 
 :::
@@ -242,14 +242,14 @@ version using its configuration. Check this with the
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 rollback aws2c6ef2b3 3580a278
+  api3/airnode-deployer:0.12.0 rollback aws2c6ef2b3 3580a278
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 rollback aws2c6ef2b3 3580a278
+  api3/airnode-deployer:0.12.0 rollback aws2c6ef2b3 3580a278
 ```
 
 :::
@@ -279,14 +279,14 @@ GCP).
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 fetch-files aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 fetch-files aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 fetch-files aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 fetch-files aws2c6ef2b3
 ```
 
 :::
@@ -309,14 +309,14 @@ the recommended way to remove a deployment, but an alternative is the
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 remove aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 remove aws2c6ef2b3
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 remove aws2c6ef2b3
+  api3/airnode-deployer:0.12.0 remove aws2c6ef2b3
 ```
 
 :::
@@ -335,14 +335,14 @@ are needed for the command to run correctly: `aws.env` (for AWS) or `gcp.json`
 ```sh [Linux/Mac/WSL2]
 docker run -it --rm \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 remove-with-receipt
+  api3/airnode-deployer:0.12.0 remove-with-receipt
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 remove-with-receipt
+  api3/airnode-deployer:0.12.0 remove-with-receipt
 ```
 
 :::

--- a/docs/reference/airnode/next/packages/admin-cli.md
+++ b/docs/reference/airnode/next/packages/admin-cli.md
@@ -104,13 +104,13 @@ npx @api3/airnode-admin $COMMAND --help
 Use the Admin CLI docker image as an alternative to `npx`:
 
 ```sh
-docker run api3/airnode-admin:0.11.0 --help
+docker run api3/airnode-admin:0.12.0 --help
 ```
 
 View the parameters of a command:
 
 ```sh
-docker run api3/airnode-admin:0.11.0 $COMMAND --help
+docker run api3/airnode-admin:0.12.0 $COMMAND --help
 ```
 
 ## SDK

--- a/docs/reference/airnode/next/understand/configuring.md
+++ b/docs/reference/airnode/next/understand/configuring.md
@@ -232,7 +232,7 @@ The `nodeSettings` field holds node-specific (Airnode) configuration parameters.
     },
     "logFormat": "plain",
     "logLevel": "INFO",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "stage": "dev"
   },
 ```

--- a/docs/reference/airnode/next/understand/deploying.md
+++ b/docs/reference/airnode/next/understand/deploying.md
@@ -101,14 +101,14 @@ need arise.
 docker run -it --rm \
   -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) \
   -v "$(pwd):/app/config" \
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 ```batch [Windows]
 # For Windows, use CMD (not PowerShell).
 docker run -it --rm ^
   -v "%cd%:/app/config" ^
-  api3/airnode-deployer:0.11.0 deploy
+  api3/airnode-deployer:0.12.0 deploy
 ```
 
 :::
@@ -134,7 +134,7 @@ deployment was successful or not.
       "disableConcurrencyReservations": false
     },
     "stage": "dev",
-    "nodeVersion": "0.11.0",
+    "nodeVersion": "0.12.0",
     "timestamp": "2022-03-26T02:37:55.506Z"
   },
   "success": true

--- a/docs/reference/airnode/next/understand/heartbeat.md
+++ b/docs/reference/airnode/next/understand/heartbeat.md
@@ -68,7 +68,7 @@ Turn on the optional heartbeat functionality by setting all fields in the
        },
       "logFormat": "json",
       "logLevel": "INFO",
-      "nodeVersion": "0.11.0",
+      "nodeVersion": "0.12.0",
       "stage": "testnet",
   }
 }


### PR DESCRIPTION
I used grep to find a number of instances of `0.11` in `latest/` and `next/` that should be `0.12`. 