### PR TITLE
fix: broken links, language, capitalization

### DIFF
--- a/docs/.vitepress/nav-boxes/nav-boxes-guides.json
+++ b/docs/.vitepress/nav-boxes/nav-boxes-guides.json
@@ -5,7 +5,7 @@
     "content": "Use the API3 Market and obtain access to self-funded dAPIs."
   },
   "_read-dapi-proxy": {
-    "btnURL": "/guides/dapis/read-self-funded-dapi/",
+    "btnURL": "/guides/dapis/read-a-dapi/",
     "title": "Reading a dAPI",
     "content": "Use a proxy contract to call a dAPI."
   },

--- a/docs/explore/airnode/unlocking-real-world-data.md
+++ b/docs/explore/airnode/unlocking-real-world-data.md
@@ -156,7 +156,7 @@ needs to be compatible with an oracle node.
 ::: info Read more
 
 This functionality includes functions such as
-[Authorizers](/reference/airnode/latest/understand/apply-auth.html). An Airnode
+[Authorizers](/reference/airnode/latest/understand/apply-auth.md). An Airnode
 can authorize smart contracts (know as requesters) access to its endpoints using
 Authorizers.
 

--- a/docs/explore/dapis/using-dapis.md
+++ b/docs/explore/dapis/using-dapis.md
@@ -52,7 +52,7 @@ already been funded and any dApp owner can proceed to use the dAPI.
 
 <!--::: info Developer info
 
-dAPI implmentation to your solidity contract is simple, learn more [within this
+dAPI implementation to your solidity contract is simple, learn more [within this
 starter kit](link to API3 DAO starter kit).
 
 :::-->
@@ -71,7 +71,7 @@ dAPIs. To use a self-funded data feed you:
 - [Fund a sponsor wallet](/guides/dapis/subscribing-self-funded-dapis/) (if not
   already funded)
 - Deploy the proxy contract (if not already deployed)
-- [Read the dAPI](/guides/dapis/read-self-funded-dapi/)
+- [Read the dAPI](/guides/dapis/read-a-dapi/)
 
   <img src="../assets/images/self_funded_market_process_notext.png" style="width:500px">
 
@@ -83,7 +83,7 @@ a [proxy contract](/reference/dapis/understand/proxy-contracts.md).
 ::: info Get started
 
 Developers can use the API3 Market now to
-[<span style="color:rgb(16, 185, 129);">read</span>](/guides/dapis/read-self-funded-dapi/)
+[<span style="color:rgb(16, 185, 129);">read</span>](/guides/dapis/read-a-dapi/)
 a self-funded dAPI.
 
 :::

--- a/docs/explore/dapis/what-are-dapis.md
+++ b/docs/explore/dapis/what-are-dapis.md
@@ -37,13 +37,13 @@ or a set of beacons and are sometimes referred to as first-party data feeds
 because they are sourced from first-party oracles. Therefore a beacon is
 directly powered and maintained on-chain by the owner of the data, the API
 provider, which effectively removes third-party middlemen that other oracle
-solutions rely on. This approach creates source transparency in addition to,
-higher security, cost-efficiency and scalability through less parties being
+solutions rely on. This approach creates source transparency in addition to
+higher security, cost-efficiency, and scalability through less parties being
 involved in the oracle service operation.
 
 ## dAPIs connect smart contracts to first-party data feeds
 
-Through the use of the proxy contract function `read()` API3 can associate the
+Through the use of the proxy contract function `read()`, API3 can associate the
 ID of a beacon or beacon set with a human-readable name like ETH/USD. The
 benefit of this approach is that dApps continue to read the same dAPI name
 without being required to make any changes to their code, effectively turning
@@ -55,8 +55,8 @@ At the core, a **dAPI** is a mapping that points towards a **beacon** or a
 **beacon set**, similarly to how an ENS name is mapped to a wallet address. The
 ability to control this mapping allows the API3 DAO to take over the management
 overhead that is associated with oracle infrastructure by e.g. creating a new
-beacon set if one first-party oracle becomes unavailable and pointing the name
-"AVAX/USD" towards the newly created ID.
+beacon set if one first-party oracle becomes unavailable and pointing the name,
+e.g. `AVAX/USD`, towards the newly created ID.
 
 ## What is a Beacon or a Beacon Set?
 
@@ -143,7 +143,7 @@ A dAPI points to an individual beacon or an aggregation of multiple beacons
 (beacon set). Each dAPI has a human-readable name (e.g., `AVAX/USD`) that makes
 them easy to categorize. The contract
 [API3ServerV1.sol](/reference/dapis/understand/) maintains the link between a
-dAPI name and the beacon(s) it uses for the dAPI. dApps use an API3 Marker proxy
+dAPI name and the beacon(s) it uses for the dAPI. dApps use an API3 Market proxy
 contract to read any dAPI from `API3ServerV1.sol`.
 
 dApp owners use a proxy contract, available on the
@@ -159,8 +159,8 @@ The `API3ServerV1.sol` contract reads directly from its data store of beacons,
 which are powered by API provider-operated
 [Airnodes](/reference/airnode/latest/). Thus proxies allow dAPIs to be used like
 libraries. The smart contract only needs to
-[import the interface](/guides/dapis/read-self-funded-dapi/) for calling the
-proxy contract.
+[import the interface](/guides/dapis/read-a-dapi/index.md#2-read-a-dapi) for
+calling the proxy contract.
 
 This means once a dAPI is integrated to read a different data feed, the contract
 does not need to change the code itself, rather it only needs to use a different
@@ -172,9 +172,9 @@ Refer to these guides and learn how to fund a self-funded dAPI and to read the
 dAPI using a proxy contract:
 
 - [Subscribing to Self-Funded dAPIs](/guides/dapis/subscribing-self-funded-dapis/index.md)
-- [Reading a Self-Funded dAPI Proxy](/guides/dapis/read-self-funded-dapi/index.md)
+- [Reading a Self-Funded dAPI Proxy](/guides/dapis/read-a-dapi/)
 
-<!--Additionally it is going to play a cruical role in setting up required
+<!--Additionally it is going to play a crucial role in setting up required
 contracts for OEV (LINK) and Service Coverage (LINK). // add this when OEV & Service Coverage pages are added-->
 
 <!--## dAPI Maintenance

--- a/docs/explore/introduction/decentralized-apis.md
+++ b/docs/explore/introduction/decentralized-apis.md
@@ -88,8 +88,8 @@ Market, dApp owners can swiftly gain access to a dAPI with minimal effort.
 Follow the guide
 [Subscribing to Self-Funded dAPIs](/guides/dapis/subscribing-self-funded-dapis/)
 to get started. Then see the guide
-[Reading a self-funded dAPI proxy](/guides/dapis/read-self-funded-dapi/) and
-understand how to read a dAPI.
+[Reading a self-funded dAPI proxy](/guides/dapis/read-a-dapi/) and understand
+how to read a dAPI.
 
 ### Managed dAPIs
 

--- a/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
+++ b/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
@@ -26,7 +26,7 @@ tags:
 
 Gelato is a third-party application that is not developed by the API3 team. The
 API3 team does not provide support for Gelato. If you have any questions or
-issues with the gelato platform, please contact the Gelato team directly.
+issues with the Gelato platform, please contact the Gelato team directly.
 
 :::
 
@@ -157,7 +157,7 @@ following parameters:
 ## 3. Creating the task
 
 Once the contract is deployed and initialized, you need to create a task on
-gelato. Head over to the
+Gelato. Head over to the
 [App Platform<ExternalLinkImage/>](https://app.gelato.network/) and connect your
 wallet.
 
@@ -205,7 +205,7 @@ create the task:
 
 Once the task is created, you need to **transfer the gas funds** to the deployed
 `Automation.sol` contract. You can do this by directly sending funds to the
-contract address. Once funded, gelato keepers will monitor the balance of the
+contract address. Once funded, Gelato keepers will monitor the balance of the
 sponsorWallets and fund the sponsorWallets if the balance is less than the
 minimum balance. A small fee will be deducted from the contract balance and sent
 to the Gelato network for providing the automation service.

--- a/docs/guides/dapis/subscribing-managed-dapis/index.md
+++ b/docs/guides/dapis/subscribing-managed-dapis/index.md
@@ -16,14 +16,14 @@ tags:
 
 # {{$frontmatter.title}}
 
-[Managed dAPIs](/explore/dapis/using-dapis.html#managed-dapis) are datafeeds
-that are sourced directly from multiple
+[Managed dAPIs](/explore/dapis/using-dapis.md#managed-dapis) are datafeeds that
+are sourced directly from multiple
 [first-party oracles](/explore/airnode/why-first-party-oracles) and aggregated
-using [Airnode's](/explore/airnode/what-is-airnode.html) signed data. It
-utilises first-party oracles, enabling data to be served directly from reputable
-API providers via the Airnode. Unlike self-funded dAPIs, API3 manages the gas
-costs and the availability of the managed dAPIs. This guide will walk you
-through the process of subscribing to a managed dAPI.
+using [Airnode's](/explore/airnode/what-is-airnode.md) signed data. It utilises
+first-party oracles, enabling data to be served directly from reputable API
+providers via the Airnode. Unlike self-funded dAPIs, API3 manages the gas costs
+and the availability of the managed dAPIs. This guide will walk you through the
+process of subscribing to a managed dAPI.
 
 ::: info Managed dAPIs
 
@@ -63,7 +63,7 @@ choose from either **Managed** or **Self-funded**. Select Managed dAPIs.
 
 Managed dAPIs gives you an option to configure the dAPI's
 [deviation threshold](/reference/dapis/understand/deviations) and
-[heartbeat](/reference/dapis/understand/deviations.html#heartbeat). For managed
+[heartbeat](/reference/dapis/understand/deviations.md#heartbeat). For managed
 dAPIs, you will have the following options to choose from:
 
 | Deviation | Heartbeat |
@@ -80,8 +80,8 @@ Check the [API3 Market](https://market.api3.org/) for more info.
 
 :::
 
-_[Click here](/reference/dapis/understand/deviations.html#update-interval) to
-read more if you are unsure what suits your dApp_
+_[Click here](/reference/dapis/understand/deviations.md#update-interval) to read
+more if you are unsure what suits your dApp_
 
 Check the final price and time frame for the selected configuration. If you are
 happy with it, select **Add to Cart**. You can also add other dAPIs on the same

--- a/docs/guides/dapis/subscribing-self-funded-dapis/index.md
+++ b/docs/guides/dapis/subscribing-self-funded-dapis/index.md
@@ -22,7 +22,7 @@ tags:
 
 > <Video src="https://www.youtube.com/embed/kY3ExNjG_9c"/>
 
-With [Self-Funded dAPIs](/explore/dapis/using-dapis.html#self-funded-dapis), you
+With [Self-Funded dAPIs](/explore/dapis/using-dapis.md#self-funded-dapis), you
 can fund the dAPI with your own funds. The amount of gas you supply will
 determine how long your dAPI will be available for use. If you run out of gas,
 you can fund the dAPI again to keep it available for use. This is a good option

--- a/docs/reference/dapis/understand/index.md
+++ b/docs/reference/dapis/understand/index.md
@@ -115,8 +115,8 @@ them ideal to use on a production chain.
 See the guide
 [Subscribing to self-funded dAPIs](/guides/dapis/subscribing-self-funded-dapis/)
 and learn more on how to fund a dAPI. Also see the guide
-[Reading a self-funded dAPI proxy](/guides/dapis/read-self-funded-dapi/) and
-learn how to use a proxy contract address to read a dAPI.
+[Reading a self-funded dAPI proxy](/guides/dapis/read-a-dapi/) and learn how to
+use a proxy contract address to read a dAPI.
 
 ## Managed dAPIs
 

--- a/docs/reference/dapis/understand/iproxy.md
+++ b/docs/reference/dapis/understand/iproxy.md
@@ -45,8 +45,8 @@ repo
 ## Usage
 
 Use the address of a proxy contract to read dAPIs with `IProxy`. See the guide
-[Reading a self-funded dAPI proxy ](/guides/dapis/read-self-funded-dapi/) for a
-complete working example. Proxy contract addresses are available on the
+[Reading a self-funded dAPI proxy ](/guides/dapis/read-a-dapi/) for a complete
+working example. Proxy contract addresses are available on the
 [API3 Market<ExternalLinkImage/>](https://market.api3.org).
 
 ```

--- a/docs/reference/dapis/understand/managed.md
+++ b/docs/reference/dapis/understand/managed.md
@@ -17,7 +17,7 @@ tags:
 # {{$frontmatter.title}}
 
 Managed dAPIs are sourced directly from multiple
-[first-party](/explore/airnode/why-first-party-oracles.html) data providers
+[first-party](/explore/airnode/why-first-party-oracles.md) data providers
 running an [Airnode](/reference/airnode/latest/understand/) and aggregated using
 Airnode's signed data. The gas costs and availability of managed dAPIs is
 managed by the dAPI team within [API3 DAO](/explore/dao-members/).
@@ -37,12 +37,12 @@ set `updateBeaconSetWithBeacons`.
 
 dAPIs are human-readable mappings that maps to a `beaconId` or `beaconSetId`.
 The `beaconId` for each dAPI gets updated when the price hits the set
-[deviation threshold](/reference/dapis/understand/deviations.html)/[heartbeat](/reference/dapis/understand/deviations.html#heartbeat)
+[deviation threshold](/reference/dapis/understand/deviations.md)/[heartbeat](/reference/dapis/understand/deviations.md#heartbeat)
 using
-[Airnode's Signed Data](/reference/airnode/latest/understand/http-gateways.html).
-[Airseeker](/reference/dapis/understand/managed.html#airseeker) and other
-entities who have access to Airnode's signed data are responsible for updating
-each individual `beaconId` for each dAPI.
+[Airnode's Signed Data](/reference/airnode/latest/understand/http-gateways.md).
+[Airseeker](/reference/dapis/understand/managed.md#airseeker) and other entities
+who have access to Airnode's signed data are responsible for updating each
+individual `beaconId` for each dAPI.
 
 A `beaconId` for each dAPI is derived from the hash of the provider's Airnode's
 address and its Template ID(a hash of one of the Airnode's `endpointId` and
@@ -61,7 +61,7 @@ Like Airnode,
 serverless lambda function that is responsible for updating the values of each
 `beaconId` for each dAPI. It is used to update the beacons with signed responses
 from
-[Airnode's HTTP-Signed-Gateway](/reference/airnode/latest/understand/http-gateways.html).
+[Airnode's HTTP-Signed-Gateway](/reference/airnode/latest/understand/http-gateways.md).
 
 Airseeker uses Airnode's built-in HTTP-Gateway to receive signed data and push
 it on-chain in a tamper proof way.
@@ -84,7 +84,7 @@ providers are listed below:
 | Cryptocurrency | Nodary, Coinpaprika, Finage, Twelvedata, NCFX, Kaiko, dxFeed            |
 | Forex          | Nodary, Finage, Twelvedata, NCFX, IEXCloud, Finnhub, dxFeed, Tradermade |
 | Commodities    | Nodary, Finage, Twelvedata, dxFeed, Tradermade                          |
-| Equities       | Nodary, Finage, Twelvedata, IEXCloud, finnhub, dxfeed                   |
+| Equities       | Nodary, Finage, Twelvedata, IEXCloud, Finnhub, dxfeed                   |
 
 All the data providers listed here are selected and properly tested by the dAPI
 team to ensure the highest quality data availability for the listed dAPIs.

--- a/docs/reference/dapis/understand/proxy-contracts.md
+++ b/docs/reference/dapis/understand/proxy-contracts.md
@@ -24,8 +24,8 @@ contract is linked to a single dAPI on a particular network.
 
 dApp owners use the address of a proxy contract to read dAPIs with the
 [IProxy interface](/reference/dapis/understand/iproxy.md). See the guide
-[Reading a self-funded dAPI proxy ](/guides/dapis/read-self-funded-dapi/) for a
-complete working example.
+[Reading a self-funded dAPI proxy ](/guides/dapis/read-a-dapi/) for a complete
+working example.
 
 ```
 import "@api3/contracts/v0.8/interfaces/IProxy.sol";

--- a/docs/reference/dapis/understand/read-dapis.md
+++ b/docs/reference/dapis/understand/read-dapis.md
@@ -41,8 +41,7 @@ the dAPI's data (`value` int224, `timestamp` uint256).
 (value, timestamp) = IProxy(0xa8785d83A31B21065F27b640F50694b39B1bda9a).read();
 ```
 
-See the guide
-[Reading a self-funded dAPI proxy](/guides/dapis/read-self-funded-dapi/) and
+See the guide [Reading a self-funded dAPI proxy](/guides/dapis/read-a-dapi/) and
 learn more on how to use a proxy contract address.
 
 <FlexEndTag/>

--- a/docs/reference/dapis/understand/self-funded.md
+++ b/docs/reference/dapis/understand/self-funded.md
@@ -23,14 +23,14 @@ unless it is funded again.
 
 ## How it works
 
-Unlike [Managed dAPIs](/reference/dapis/understand/managed.html), self-funded
+Unlike [Managed dAPIs](/reference/dapis/understand/managed.md), self-funded
 dAPIs are single-source data feeds. The data is sourced from a single
-[first-party](/explore/airnode/why-first-party-oracles.html) data provider
-running an [Airnode](/reference/airnode/latest/understand/) and an
-[Airseeker](/reference/dapis/understand/self-funded.html#airseeker) which
-updates the `beaconId` with Airnode's signed data. The gas costs for self-funded
-dAPIs are managed by the users themselves. As long as the sponsor wallet of the
-dAPI has enough gas, it will be updated.
+[first-party](/explore/airnode/why-first-party-oracles.md) data provider running
+an [Airnode](/reference/airnode/latest/understand/) and an
+[Airseeker](/reference/dapis/understand/self-funded.md#airseeker) which updates
+the `beaconId` with Airnode's signed data. The gas costs for self-funded dAPIs
+are managed by the users themselves. As long as the sponsor wallet of the dAPI
+has enough gas, it will be updated.
 
 Datafeed values for Self-funded dAPIs are also stored on-chain within the same
 [`Api3ServerV1.sol`<ExternalLinkImage/>](https://github.com/api3dao/airnode-protocol-v1/tree/79b509f0e88a96fa4ea3cd576685051d37c9a504/contracts/api3-server-v1)
@@ -56,7 +56,7 @@ Like Airnode,
 serverless lambda function that is responsible for updating the values of each
 `beaconId` for each dAPI. It is used to update the beacons with signed responses
 from
-[Airnode's HTTP-Gateway](/reference/airnode/latest/understand/http-gateways.html).
+[Airnode's HTTP-Gateway](/reference/airnode/latest/understand/http-gateways.md).
 
 Airseeker uses Airnode's built-in HTTP-Gateway to receive signed data and push
 it on-chain in a tamper proof way.
@@ -65,8 +65,8 @@ Similar to Airnode's OIS, Airseeker also requires a configuration file that is
 used to configure the Airseeker.
 [Click here to see an example of an Airseeker configuration file.<ExternalLinkImage/>](https://github.com/api3dao/airseeker/blob/main/config/airseeker.example.json).
 The configuration file is used to configure the
-[deviation thresholds](/reference/dapis/understand/deviations.html) and
-[heartbeat](/reference/dapis/understand/deviations.html#heartbeat) for each
+[deviation thresholds](/reference/dapis/understand/deviations.md) and
+[heartbeat](/reference/dapis/understand/deviations.md#heartbeat) for each
 `beaconId`. For self-funded dAPIs, the deviation threshold is set to 1% and the
 heartbeat is set to 24 hours.
 


### PR DESCRIPTION
An issue was that the page `/guides/dapis/read-self-funded-dapi/` got renamed to `/guides/dapis/read-a-dapi/` in #554 without that change being propagated through the various site pages. Other changes are minor like consistent capitalization, a few spelling errors, and `.md` links instead of `.html`.