### PR TITLE
broken links w/anchors, one typo

### DIFF
--- a/docs/explore/dapis/what-are-dapis.md
+++ b/docs/explore/dapis/what-are-dapis.md
@@ -159,7 +159,7 @@ The `API3ServerV1.sol` contract reads directly from its data store of beacons,
 which are powered by API provider-operated
 [Airnodes](/reference/airnode/latest/). Thus proxies allow dAPIs to be used like
 libraries. The smart contract only needs to
-[import the interface](/guides/dapis/read-a-dapi/index.md#2-read-a-dapi) for
+[import the interface](/guides/dapis/read-a-dapi/index.md#_2-read-a-dapi) for
 calling the proxy contract.
 
 This means once a dAPI is integrated to read a different data feed, the contract

--- a/docs/guides/dapis/subscribing-managed-dapis/index.md
+++ b/docs/guides/dapis/subscribing-managed-dapis/index.md
@@ -49,10 +49,10 @@ process consists of:
 
 ## Exploring, selecting and configuring your dAPI
 
-The [API3 Market<ExternalLinkImage/>](market.api3.org/) provides a list of all
-the dAPIs available across multiple chains including testnets. You can filter
-the list by chains and data providers. You can also search for a specific dAPI
-by name. Once selected, you will land on the details page
+The [API3 Market<ExternalLinkImage/>](https://market.api3.org/) provides a list
+of all the dAPIs available across multiple chains including testnets. You can
+filter the list by chains and data providers. You can also search for a specific
+dAPI by name. Once selected, you will land on the details page
 [(eg ETH/USD on polygon)<ExternalLinkImage/>](https://market.api3.org/dapis/polygon/ETH-USD)
 where you can find more information about the dAPI.
 

--- a/docs/guides/dapis/subscribing-self-funded-dapis/index.md
+++ b/docs/guides/dapis/subscribing-self-funded-dapis/index.md
@@ -46,7 +46,7 @@ end-to-end process consists of:
 
 - [Exploring and selecting your data feed](/guides/dapis/subscribing-self-funded-dapis/#_1-exploring-and-selecting-your-data-feed)
   <br/>
-- [Funding a sponsor wallet](/dapis/subscribing-self-funded-dapis/#_2-funding-a-sponsor-wallet)
+- [Funding a sponsor wallet](/guides/dapis/subscribing-self-funded-dapis/#_2-funding-a-sponsor-wallet)
   <br/>
 - [Deploying a proxy contract to access the data feed](/guides/dapis/subscribing-self-funded-dapis/#_3-deploying-a-proxy-contract-to-access-the-data-feed)
   <br/>

--- a/docs/guides/qrng/roulette-guide/index.md
+++ b/docs/guides/qrng/roulette-guide/index.md
@@ -853,7 +853,7 @@ Now you're ready to make a bet of your choice.
 - use `betEvenOdd()` to bet on either the set of all even or odd numbers on the
   board.
 - use `betColor()` to bet on all the red or black numbers on the board.
-- use `betNumber()` to bet on any one number you wishe on the board.
+- use `betNumber()` to bet on any one number you wish on the board.
 
 For this example, let's bet on all the even numbers of the table. As the
 `MIN_BET` is set to be `10000000000000` wei, we'll use that value for making the


### PR DESCRIPTION
There were a few broken links due to the use of anchors, a missing protocol, and a missing section (guides) path element.