### PR TITLE
fix: remove fulfillmentGasLimit and contracts from config.json

### DIFF
--- a/docs/guides/airnode/deploy-airnode/deploy-aws/src/config.json
+++ b/docs/guides/airnode/deploy-airnode/deploy-aws/src/config.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x2ab9f26E18B64848cd349582ca3B55c2d06f507d"
-      },
       "id": "11155111",
       "providers": {
         "myChainProvider": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/guides/airnode/deploy-airnode/deploy-container/src/config.json
+++ b/docs/guides/airnode/deploy-airnode/deploy-container/src/config.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x2ab9f26E18B64848cd349582ca3B55c2d06f507d"
-      },
       "id": "11155111",
       "providers": {
         "myChainProvider": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/guides/airnode/deploy-airnode/deploy-gcp/src/config.json
+++ b/docs/guides/airnode/deploy-airnode/deploy-gcp/src/config.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x2ab9f26E18B64848cd349582ca3B55c2d06f507d"
-      },
       "id": "11155111",
       "providers": {
         "myChainProvider": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/guides/airnode/post-processing/src/config.json
+++ b/docs/guides/airnode/post-processing/src/config.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x2ab9f26E18B64848cd349582ca3B55c2d06f507d"
-      },
       "id": "11155111",
       "providers": {
         "myChainProvider": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/reference/airnode/latest/concepts/chain-providers.md
+++ b/docs/reference/airnode/latest/concepts/chain-providers.md
@@ -52,9 +52,6 @@ which is interpolated from `secrets.env`.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -63,7 +60,6 @@ which is interpolated from `secrets.env`.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",
@@ -117,9 +113,6 @@ Simply add another uniquely named object to `providers` as shown below.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -131,7 +124,6 @@ Simply add another uniquely named object to `providers` as shown below.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/reference/airnode/latest/deployment-files/examples/config-cloud.json
+++ b/docs/reference/airnode/latest/deployment-files/examples/config-cloud.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-      },
       "id": "11155111",
       "providers": {
         "infuraSepolia": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",

--- a/docs/reference/airnode/latest/deployment-files/examples/config-local.json
+++ b/docs/reference/airnode/latest/deployment-files/examples/config-local.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-      },
       "id": "31337",
       "providers": {
         "local": {
@@ -22,7 +19,6 @@
       "type": "evm",
       "options": {},
       "maxConcurrency": 100,
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "providerRecommendedGasPrice",

--- a/docs/reference/airnode/latest/deployment-files/templates/config-json.md
+++ b/docs/reference/airnode/latest/deployment-files/templates/config-json.md
@@ -62,9 +62,6 @@ as a reference while building a config.json file.
           "<FILL_ENDPOINT_ID_1>" : ["<FILL_*>"]
         }
       },
-      "contracts": {
-        "AirnodeRrp": "<FILL_*>"
-      },
       "id": "<FILL_*>",
       "providers": {
         "<FILL_PROVIDER_NAME_1>": {
@@ -73,7 +70,6 @@ as a reference while building a config.json file.
       },
       "type": "<FILL_*>",
       "options": {
-        "fulfillmentGasLimit": <FILL_NUMBER>,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/reference/airnode/latest/understand/apply-auth.md
+++ b/docs/reference/airnode/latest/understand/apply-auth.md
@@ -107,9 +107,6 @@ Below are examples of how to use the authorizers.
             "requesterEndpointAuthorizers": ["0xCE5e...1abc"],
             "chainType": "evm",
             "chainId": "1",
-            "contracts": {
-              "AirnodeRrp": "0xa0AD...a1Bd"
-            },
             "chainProvider": {
               "url": "https://mainnet.infura.io/..."
             }
@@ -146,9 +143,6 @@ Below are examples of how to use the authorizers.
             "erc721s": ["0x3FbDB2315678afecb367f032d93F642f64180aa6"],
             "chainType": "evm",
             "chainId": "1",
-            "contracts": {
-              "RequesterAuthorizerWithErc721": "0x6bbbb2315678afecb367f032d93F642f64180aa4"
-            },
             "chainProvider": {
               "url": "http://127.0.0.2"
             }

--- a/docs/reference/airnode/latest/understand/configuring.md
+++ b/docs/reference/airnode/latest/understand/configuring.md
@@ -82,9 +82,6 @@ Below is a simple chain array with a single chain provider.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -93,7 +90,6 @@ Below is a simple chain array with a single chain provider.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",
@@ -190,12 +186,10 @@ The links below offer additional details for each field from the Deployment
 Files section:
 
 - [authorizers](/reference/airnode/latest/deployment-files/config-json.md#authorizers)
-- [contracts](/reference/airnode/latest/deployment-files/config-json.md#contracts)
 - [id](/reference/airnode/latest/deployment-files/config-json.md#id)
 - [providers](/reference/airnode/latest/deployment-files/config-json.md#providers)
 - [type](/reference/airnode/latest/deployment-files/config-json.md#type)
 - [options](/reference/airnode/latest/deployment-files/config-json.md#options)
-  - [options.fulfillmentGasLimit](/reference/airnode/latest/deployment-files/config-json.md#options-fulfillmentgaslimit)
   - [options.gasPriceOracle](/reference/airnode/latest/deployment-files/config-json.md#options-gaspriceoracle-n)
   - [options.withdrawalRemainder](/reference/airnode/latest/deployment-files/config-json.md#options-withdrawalremainder)
 - [maxConcurrency](/reference/airnode/latest/deployment-files/config-json.md#maxconcurrency)

--- a/docs/reference/airnode/next/concepts/chain-providers.md
+++ b/docs/reference/airnode/next/concepts/chain-providers.md
@@ -52,9 +52,6 @@ which is interpolated from `secrets.env`.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -63,7 +60,6 @@ which is interpolated from `secrets.env`.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",
@@ -117,9 +113,6 @@ Simply add another uniquely named object to `providers` as shown below.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -131,7 +124,6 @@ Simply add another uniquely named object to `providers` as shown below.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/reference/airnode/next/deployment-files/examples/config-cloud.json
+++ b/docs/reference/airnode/next/deployment-files/examples/config-cloud.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-      },
       "id": "11155111",
       "providers": {
         "infuraSepolia": {
@@ -21,7 +18,6 @@
       },
       "type": "evm",
       "options": {
-        "fulfillmentGasLimit": 500000,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "providerRecommendedGasPrice",

--- a/docs/reference/airnode/next/deployment-files/examples/config-local.json
+++ b/docs/reference/airnode/next/deployment-files/examples/config-local.json
@@ -10,9 +10,6 @@
       "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-      "contracts": {
-        "AirnodeRrp": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-      },
       "id": "31337",
       "providers": {
         "local": {
@@ -22,7 +19,6 @@
       "type": "evm",
       "options": {},
       "maxConcurrency": 100,
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "providerRecommendedGasPrice",

--- a/docs/reference/airnode/next/deployment-files/templates/config-json.md
+++ b/docs/reference/airnode/next/deployment-files/templates/config-json.md
@@ -62,9 +62,6 @@ as a reference while building a config.json file.
           "<FILL_ENDPOINT_ID_1>" : ["<FILL_*>"]
         }
       },
-      "contracts": {
-        "AirnodeRrp": "<FILL_*>"
-      },
       "id": "<FILL_*>",
       "providers": {
         "<FILL_PROVIDER_NAME_1>": {
@@ -73,7 +70,6 @@ as a reference while building a config.json file.
       },
       "type": "<FILL_*>",
       "options": {
-        "fulfillmentGasLimit": <FILL_NUMBER>,
         "gasPriceOracle": [
           {
             "gasPriceStrategy": "latestBlockPercentileGasPrice",

--- a/docs/reference/airnode/next/understand/apply-auth.md
+++ b/docs/reference/airnode/next/understand/apply-auth.md
@@ -107,9 +107,6 @@ Below are examples of how to use the authorizers.
             "requesterEndpointAuthorizers": ["0xCE5e...1abc"],
             "chainType": "evm",
             "chainId": "1",
-            "contracts": {
-              "AirnodeRrp": "0xa0AD...a1Bd"
-            },
             "chainProvider": {
               "url": "https://mainnet.infura.io/..."
             }
@@ -146,9 +143,6 @@ Below are examples of how to use the authorizers.
             "erc721s": ["0x3FbDB2315678afecb367f032d93F642f64180aa6"],
             "chainType": "evm",
             "chainId": "1",
-            "contracts": {
-              "RequesterAuthorizerWithErc721": "0x6bbbb2315678afecb367f032d93F642f64180aa4"
-            },
             "chainProvider": {
               "url": "http://127.0.0.2"
             }

--- a/docs/reference/airnode/next/understand/configuring.md
+++ b/docs/reference/airnode/next/understand/configuring.md
@@ -82,9 +82,6 @@ Below is a simple chain array with a single chain provider.
     "authorizations": {
         "requesterEndpointAuthorizations": {}
       },
-    "contracts": {
-      "AirnodeRrp": "0xa0AD79D995DdeeB18a14eAef56A549A04e3Aa1Bd"
-    },
     "id": "11155111",
     "providers": {
       "infuraSepolia": {
@@ -93,7 +90,6 @@ Below is a simple chain array with a single chain provider.
     },
     "type": "evm",
     "options": {
-      "fulfillmentGasLimit": 500000,
       "gasPriceOracle": [
         {
           "gasPriceStrategy": "latestBlockPercentileGasPrice",
@@ -190,12 +186,10 @@ The links below offer additional details for each field from the Deployment
 Files section:
 
 - [authorizers](/reference/airnode/next/deployment-files/config-json.md#authorizers)
-- [contracts](/reference/airnode/next/deployment-files/config-json.md#contracts)
 - [id](/reference/airnode/next/deployment-files/config-json.md#id)
 - [providers](/reference/airnode/next/deployment-files/config-json.md#providers)
 - [type](/reference/airnode/next/deployment-files/config-json.md#type)
 - [options](/reference/airnode/next/deployment-files/config-json.md#options)
-  - [options.fulfillmentGasLimit](/reference/airnode/next/deployment-files/config-json.md#options-fulfillmentgaslimit)
   - [options.gasPriceOracle](/reference/airnode/next/deployment-files/config-json.md#options-gaspriceoracle-n)
   - [options.withdrawalRemainder](/reference/airnode/next/deployment-files/config-json.md#options-withdrawalremainder)
 - [maxConcurrency](/reference/airnode/next/deployment-files/config-json.md#maxconcurrency)


### PR DESCRIPTION
Closes #611 and closes #614.

Note that although these are being removed because defaults are
automatically provided, they are still valid within the config.json file
and therefore each is still described within the deployment-files
reference e.g. [here](https://docs.api3.org/reference/airnode/latest/deployment-files/config-json.html#chains).