### PR TITLE
feat: add zip file generation and validation scripts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn run format:check
+yarn run zip:config-check

--- a/docs/dev/sidebar.js
+++ b/docs/dev/sidebar.js
@@ -23,6 +23,7 @@ module.exports = [
       { text: 'Google Analytics 4', link: '/dev/ga4' },
       { text: 'VitePress Containers', link: '/dev/containers' },
       { text: 'SSR on CloudFlare', link: '/dev/ssr' },
+      { text: 'Zip File Handling', link: '/dev/zip-handling' },
     ],
   },
 ];

--- a/docs/dev/zip-handling.md
+++ b/docs/dev/zip-handling.md
@@ -1,0 +1,33 @@
+---
+title: Zip File Handling
+sidebarHeader: Docs Development
+sidebarSubHeader:
+pageHeader: Docs Development
+basePath: /dev/zip-handling.html
+outline: deep
+tags:
+---
+
+<PageHeader/>
+
+# {{$frontmatter.title}}
+
+Zip files are available for three quick-start Airnode deployment guides:
+
+1. [AWS](/guides/airnode/deploy-airnode/deploy-aws/)
+2. [GCP](/guides/airnode/deploy-airnode/deploy-gcp/)
+3. [Local](/guides/airnode/deploy-airnode/deploy-container/)
+
+To facilitate the creation of these zip files, the following script can be run:
+
+```sh
+yarn zip:create
+```
+
+To ensure that the `config.json` files within these zip files do not get
+out-of-sync with their input `config.json` files, the following script is run as
+part of the pre-push hook (it can also be run independently):
+
+```sh
+yarn zip:config-check
+```

--- a/libs/checkZipConfigs.js
+++ b/libs/checkZipConfigs.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+const jsdiff = require('diff');
+
+const filePairs = [
+  {
+    configPath: 'docs/guides/airnode/deploy-airnode/deploy-aws/src/config.json',
+    zipFilePath: 'docs/public/zip-files/quick-start-aws.zip',
+  },
+  {
+    configPath: 'docs/guides/airnode/deploy-airnode/deploy-gcp/src/config.json',
+    zipFilePath: 'docs/public/zip-files/quick-start-gcp.zip',
+  },
+  {
+    configPath:
+      'docs/guides/airnode/deploy-airnode/deploy-container/src/config.json',
+    zipFilePath: 'docs/public/zip-files/quick-start-container.zip',
+  },
+];
+
+// Function to compare the contents of config.json in a file and a zip archive
+function compareConfigContents(configPath, zipFilePath) {
+  // Read the contents of config.json from a file
+  const configFileContent = fs.readFileSync(configPath, 'utf8');
+
+  // Read the contents of config.json from the zip archive
+  const zip = new AdmZip(zipFilePath);
+  const zipConfigEntry = zip.getEntry('config.json');
+  if (!zipConfigEntry) {
+    throw new Error(`config.json not found in ${zipFilePath}`);
+  }
+  const zipConfigContent = zipConfigEntry.getData().toString('utf8');
+
+  // Compare the contents
+  if (configFileContent === zipConfigContent) {
+    console.log(
+      `Contents of config.json in ${configPath} and ${zipFilePath} are identical.`
+    );
+  } else {
+    hasDifference = true;
+    const differences = jsdiff.diffLines(configFileContent, zipConfigContent);
+
+    process.stdout.write(
+      `Error: Contents of config.json in \x1b[31m${configPath}\x1b[0m and \x1b[32m${zipFilePath}\x1b[0m differ.\n\n`
+    );
+    differences.forEach((part) => {
+      if (part.added || part.removed) {
+        const color = part.added ? '\x1b[32m' : '\x1b[31m';
+        process.stdout.write(color + part.value + '\x1b[0m');
+      }
+    });
+
+    console.log('\n'); // Add a newline to separate output for each pair
+  }
+}
+
+// Loop through the file pairs and compare their contents
+let hasDifference = false;
+for (const pair of filePairs) {
+  compareConfigContents(pair.configPath, pair.zipFilePath);
+}
+
+process.exit(hasDifference ? 1 : 0);

--- a/libs/createZipFiles.js
+++ b/libs/createZipFiles.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+
+const filePairs = [
+  {
+    srcPath: 'docs/guides/airnode/deploy-airnode/deploy-aws/src',
+    zipFilePath: 'docs/public/zip-files/quick-start-aws.zip',
+  },
+  {
+    srcPath: 'docs/guides/airnode/deploy-airnode/deploy-gcp/src',
+    zipFilePath: 'docs/public/zip-files/quick-start-gcp.zip',
+  },
+  {
+    srcPath: 'docs/guides/airnode/deploy-airnode/deploy-container/src',
+    zipFilePath: 'docs/public/zip-files/quick-start-container.zip',
+  },
+];
+
+// loop through the file pairs and create a zip file for all of the files in srcPath and save it to zipFilePath
+for (const pair of filePairs) {
+  const zip = new AdmZip();
+  const files = fs.readdirSync(pair.srcPath);
+  console.log(`Creating zip file from: ${pair.srcPath}`);
+  for (const file of files) {
+    console.log(`\tAdding file: ${file}`);
+    zip.addLocalFile(`${pair.srcPath}/${file}`);
+  }
+  console.log(`Writing zip file to: ${pair.zipFilePath}\n`);
+  zip.writeZip(pair.zipFilePath);
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "flex:build": "node libs/flexBuildIndexes.js; yarn format;",
     "flex:test": "node libs/flexTestSearch.js;",
     "axios:build": "node libs/axiosBuildScripts.js; yarn format;",
+    "zip:create": "node libs/createZipFiles.js;",
     "zip:config-check": "node libs/checkZipConfigs.js;"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
     "prepare": "husky install",
     "flex:build": "node libs/flexBuildIndexes.js; yarn format;",
     "flex:test": "node libs/flexTestSearch.js;",
-    "axios:build": "node libs/axiosBuildScripts.js; yarn format;"
+    "axios:build": "node libs/axiosBuildScripts.js; yarn format;",
+    "zip:config-check": "node libs/checkZipConfigs.js;"
   },
   "devDependencies": {
     "@api3/chains": "^3.4.2",
+    "adm-zip": "^0.5.10",
     "axios": "^1.2.1",
     "colors": "^1.4.0",
+    "diff": "^5.1.0",
     "ethers": "^6.5.1",
     "file": "^0.2.2",
     "flexsearch": "^0.7.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,6 +439,11 @@
   dependencies:
     vue-demi ">=0.14.5"
 
+adm-zip@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
+
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
@@ -580,6 +585,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dom-serializer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We are prone to forgetting to update the zipped versions of `config.json` when making updates. For example, see #561, or most recently myself in #621.

This PR adds two simple scripts:
1. A script to generate each of the 3 zip files
2. A simple `pre-push` script to check that the `config.json` src files match the `config.json` files within their respective zip archives. I've tested this script works by committing a `config.json` change without updating the zip file and the push fails.

I've checked the two scripts work together by first running `yarn zip:create` then `yarn zip:config-check` and the checks pass.