### PR TITLE
feat(ois): make operationParameter optional within endpoint parameters

### DIFF
--- a/docs/reference/ois/next/specification.md
+++ b/docs/reference/ois/next/specification.md
@@ -522,8 +522,9 @@ following elements:
 
 #### 5.5.1. `operationParameter`
 
-(Required) An object that refers to a parameter of an API operation, has the
-following elements:
+(Optional) An object that refers to a parameter of an API operation and has the
+below elements. Note that if omitted, the `parameter` will not be included as
+part of the request to the API endpoint.
 
 - `name`
 - `in`


### PR DESCRIPTION
Documentation for:
- https://github.com/api3dao/ois/pull/102 (applies to OIS v2.2.0)
- https://github.com/api3dao/airnode/issues/1800 (will be part of Airnode v0.13)

Only the `/next` version of the OIS reference is changed as the current (`/latest`) is v2.1.0 and `/next` will be v2.2.0