### PR TITLE
Update qrng provider nodary

### DIFF
--- a/docs/guides/qrng/lottery-guide/index.md
+++ b/docs/guides/qrng/lottery-guide/index.md
@@ -25,7 +25,7 @@ these two tools is assumed.
 
 Currently, QRNG has three [providers](/reference/qrng/providers.md), two of
 which provide quantum random numbers. This guide will use the
-[Nodary provider<ExternalLinkImage/>](https://nodary.io/), available only on
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers), available only on
 testnets, which returns a pseudorandom number.
 
 Anyone can choose a number 1–10,000 and buy a ticket to enter into a weekly
@@ -270,11 +270,11 @@ command
 from the Admin CLI. Use the value of the sponsor wallet address that the command
 outputs while making the request. **This wallet needs to be funded.**
 
-::: details Nodary QRNG Airnode Details
+::: details Testnet Random Numbers QRNG Airnode Details
 
 ```
-nodary QRNG Airnode Address = 0x6238772544f029ecaBfDED4300f13A3c4FE84E1D
-nodary QRNG Airnode XPUB = xpub6CuDdF9zdWTRuGybJPuZUGnU4suZowMmgu15bjFZT2o6PUtk4Lo78KGJUGBobz3pPKRaN9sLxzj21CMe6StP3zUsd8tWEJPgZBesYBMY7Wo
+Testnet Random Numbers QRNG Airnode Address = 0x6238772544f029ecaBfDED4300f13A3c4FE84E1D
+Testnet Random Numbers QRNG Airnode XPUB = xpub6CuDdF9zdWTRuGybJPuZUGnU4suZowMmgu15bjFZT2o6PUtk4Lo78KGJUGBobz3pPKRaN9sLxzj21CMe6StP3zUsd8tWEJPgZBesYBMY7Wo
 ```
 
 :::

--- a/docs/guides/qrng/lottery-guide/index.md
+++ b/docs/guides/qrng/lottery-guide/index.md
@@ -25,8 +25,8 @@ these two tools is assumed.
 
 Currently, QRNG has three [providers](/reference/qrng/providers.md), two of
 which provide quantum random numbers. This guide will use the
-[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers), available only on
-testnets, which returns a pseudorandom number.
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers),
+available only on testnets, which returns a pseudorandom number.
 
 Anyone can choose a number 1–10,000 and buy a ticket to enter into a weekly
 lottery. The ticket revenue is collected into a pot in the contract. After 7

--- a/docs/guides/qrng/qrng-remix/index.md
+++ b/docs/guides/qrng/qrng-remix/index.md
@@ -41,8 +41,8 @@ these two tools is assumed.
 
 Currently, QRNG has three [providers](/reference/qrng/providers.md), two of
 which provide quantum random numbers. This guide will use the
-[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers), available only on
-testnets, which returns a pseudorandom number.
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers),
+available only on testnets, which returns a pseudorandom number.
 
 <!-- To begin, you need to deploy and sponsor the
 [`RemixQrngExample`](/reference/qrng/qrng-example.md) with a matching
@@ -359,8 +359,8 @@ testnet ETH before moving forward. You can request some from here➚
 :::
 
 This guide will use the
-[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers) which has the same
-usage as the production quantum random number generator
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers) which
+has the same usage as the production quantum random number generator
 [providers](/reference/qrng/providers.md) but returns a pseudorandom number.
 
 - Switch to the **DEPLOY & RUN TRANSACTIONS** tab. Use MetaMask and switch to
@@ -385,11 +385,11 @@ usage as the production quantum random number generator
 
 ::: info Testnet Random Numbers Provider
 
-This guide uses Testnet Random Numbers as the QRNG Airnode provider. Testnet Random Numbers emulates QRNG on
-testnets. If you wish to use QRNG in production, you can use the mainnet
-[QRNG providers](/reference/qrng/providers.md) instead. Also make sure to check
-if your particular chain is supported by the QRNG providers. Check which chains
-are supported [here](/reference/qrng/chains.md).
+This guide uses Testnet Random Numbers as the QRNG Airnode provider. Testnet
+Random Numbers emulates QRNG on testnets. If you wish to use QRNG in production,
+you can use the mainnet [QRNG providers](/reference/qrng/providers.md) instead.
+Also make sure to check if your particular chain is supported by the QRNG
+providers. Check which chains are supported [here](/reference/qrng/chains.md).
 
 :::
 

--- a/docs/guides/qrng/qrng-remix/index.md
+++ b/docs/guides/qrng/qrng-remix/index.md
@@ -41,7 +41,7 @@ these two tools is assumed.
 
 Currently, QRNG has three [providers](/reference/qrng/providers.md), two of
 which provide quantum random numbers. This guide will use the
-[Nodary provider<ExternalLinkImage/>](https://nodary.io/), available only on
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers), available only on
 testnets, which returns a pseudorandom number.
 
 <!-- To begin, you need to deploy and sponsor the
@@ -359,7 +359,7 @@ testnet ETH before moving forward. You can request some from here➚
 :::
 
 This guide will use the
-[Nodary provider<ExternalLinkImage/>](https://nodary.io/) which has the same
+[Testnet Random Numbers](/reference/qrng/providers#testnet-random-numbers) which has the same
 usage as the production quantum random number generator
 [providers](/reference/qrng/providers.md) but returns a pseudorandom number.
 
@@ -383,9 +383,9 @@ usage as the production quantum random number generator
 
 ## 4. Setting the Parameters
 
-::: info Nodary Provider
+::: info Testnet Random Numbers Provider
 
-This guide uses Nodary as the QRNG Airnode provider. Nodary emulates QRNG on
+This guide uses Testnet Random Numbers as the QRNG Airnode provider. Testnet Random Numbers emulates QRNG on
 testnets. If you wish to use QRNG in production, you can use the mainnet
 [QRNG providers](/reference/qrng/providers.md) instead. Also make sure to check
 if your particular chain is supported by the QRNG providers. Check which chains
@@ -405,19 +405,19 @@ Next, select and expand the **`setRequestParameters`** function to see all the
 parameters that are needed.
 
 - `_airnode`: The airnode address of the desired QRNG service provider. Use
-  **Nodary**
+  **Testnet Random Numbers**
   (`0x6238772544f029ecaBfDED4300f13A3c4FE84E1D`→<CopyIcon text="0x6238772544f029ecaBfDED4300f13A3c4FE84E1D"/>).
 
-- `_endpointIdUint256`: The **Nodary** Airnode endpoint ID
+- `_endpointIdUint256`: The **Testnet Random Numbers** Airnode endpoint ID
   (`0x94555f83f1addda23fdaa7c74f27ce2b764ed5cc430c66f5ff1bcf39d583da36`→<CopyIcon text="0x94555f83f1addda23fdaa7c74f27ce2b764ed5cc430c66f5ff1bcf39d583da36"/>)
   which will return a single random number.
 
-- `_endpointIdUint256Array`: The **Nodary** Airnode endpoint ID
+- `_endpointIdUint256Array`: The **Testnet Random Numbers** Airnode endpoint ID
   (`0x9877ec98695c139310480b4323b9d474d48ec4595560348a2341218670f7fbc2`→<CopyIcon text="0x9877ec98695c139310480b4323b9d474d48ec4595560348a2341218670f7fbc2"/>)
   which will return an array of random numbers.
 
 - `_sponsorWallet`: A wallet derived from the Airnode address and the Airnode
-  xpub used by **Nodary**, and the smart contract address for
+  xpub used by **Testnet Random Numbers**, and the smart contract address for
   `RemixQrngExample.sol`. The wallet is used to pay gas costs to acquire a
   random number. A sponsor wallet must be derived using the command
   [derive-sponsor-wallet-address](/reference/airnode/latest/packages/admin-cli.md#derive-sponsor-wallet-address)
@@ -430,8 +430,8 @@ parameters that are needed.
     --airnode-xpub xpub6CuDdF9zdWTRuGybJPuZUGnU4suZowMmgu15bjFZT2o6PUtk4Lo78KGJUGBobz3pPKRaN9sLxzj21CMe6StP3zUsd8tWEJPgZBesYBMY7Wo \
     --sponsor-address <use-the-address-of: RemixQrngExample.sol>
 
-    # --airnode-address: Airnode address (nodary provider)
-    # --airnode-xpub:    Airnode xpub (nodary provider)
+    # --airnode-address: Airnode address (Testnet Random Numbers provider)
+    # --airnode-xpub:    Airnode xpub (Testnet Random Numbers provider)
     # --sponsor-address: Use the smart contract address for
     #                    RemixQrngExample.sol as displayed in the Remix IDE.
 

--- a/docs/guides/qrng/roulette-guide/index.md
+++ b/docs/guides/qrng/roulette-guide/index.md
@@ -788,11 +788,11 @@ outputs while making the request.
 
 **This wallet needs to be funded.**
 
-::: details Nodary QRNG Airnode Details
+::: details Testnet Random Numbers QRNG Airnode Details
 
 ```
-nodary QRNG Airnode Address = 0x6238772544f029ecaBfDED4300f13A3c4FE84E1D
-nodary QRNG Airnode XPUB = xpub6CuDdF9zdWTRuGybJPuZUGnU4suZowMmgu15bjFZT2o6PUtk4Lo78KGJUGBobz3pPKRaN9sLxzj21CMe6StP3zUsd8tWEJPgZBesYBMY7Wo
+Testnet Random Numbers QRNG Airnode Address = 0x6238772544f029ecaBfDED4300f13A3c4FE84E1D
+Testnet Random Numbers QRNG Airnode XPUB = xpub6CuDdF9zdWTRuGybJPuZUGnU4suZowMmgu15bjFZT2o6PUtk4Lo78KGJUGBobz3pPKRaN9sLxzj21CMe6StP3zUsd8tWEJPgZBesYBMY7Wo
 ```
 
 :::

--- a/docs/reference/qrng/chains.md
+++ b/docs/reference/qrng/chains.md
@@ -69,7 +69,7 @@ The
 [@api3/airnode-protocol<ExternalLinkImage/>](https://www.npmjs.com/package/@api3/airnode-protocol)
 package is distributed via npm.
 
-[**Nodary**](/reference/qrng/chains.md#nodary) imitates QRNG using pseudorandom
+[**Testnet Random Numbers**](/reference/qrng/chains.md#testnet-random-numbers) imitates QRNG using pseudorandom
 numbers and is best used during development. Use
 [ANU](/reference/qrng/chains.md#anu) or
 [Quintessence](/reference/qrng/chains.md#quintessence) in production to acquire
@@ -112,16 +112,16 @@ ANU is only available on mainnets.
 
 </div>
 
-## Nodary
+## Testnet Random Numbers
 
-**Nodary** is best used for development and is only available on several
+**Testnet Random Numbers** is best used for development and is only available on several
 testnets.
 
 ### Testnets
 
 <div class="testnets">
 
-<div style="position:absolute;right:0px;margin-top:-30px;">Nodary</div>
+<div style="position:absolute;right:0px;margin-top:-30px;">Testnet Random Numbers</div>
 
 | Network                                                                               | ID       | AirnodeRrpV0 Address                                                                                                 | minConfirmations |
 | ------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---------------- |

--- a/docs/reference/qrng/chains.md
+++ b/docs/reference/qrng/chains.md
@@ -69,9 +69,9 @@ The
 [@api3/airnode-protocol<ExternalLinkImage/>](https://www.npmjs.com/package/@api3/airnode-protocol)
 package is distributed via npm.
 
-[**Testnet Random Numbers**](/reference/qrng/chains.md#testnet-random-numbers) imitates QRNG using pseudorandom
-numbers and is best used during development. Use
-[ANU](/reference/qrng/chains.md#anu) or
+[**Testnet Random Numbers**](/reference/qrng/chains.md#testnet-random-numbers)
+imitates QRNG using pseudorandom numbers and is best used during development.
+Use [ANU](/reference/qrng/chains.md#anu) or
 [Quintessence](/reference/qrng/chains.md#quintessence) in production to acquire
 quantum random numbers.
 
@@ -114,8 +114,8 @@ ANU is only available on mainnets.
 
 ## Testnet Random Numbers
 
-**Testnet Random Numbers** is best used for development and is only available on several
-testnets.
+**Testnet Random Numbers** is best used for development and is only available on
+several testnets.
 
 ### Testnets
 

--- a/docs/reference/qrng/providers.md
+++ b/docs/reference/qrng/providers.md
@@ -84,21 +84,6 @@ Testnet Random Numbers emulates QRNG using
 [pseudorandom numbers<ExternalLinkImage/>](https://www.mathworks.com/help/stats/generating-random-data.html)
 on testnets to get familiar with QRNG.
 
-| Testnet                   | Chain Id |
-| ------------------------- | -------- |
-| Goerli                    | 5        |
-| Sepolia                   | 11155111 |
-| RSK testnet               | 31       |
-| POA Network Sokol testnet | 77       |
-| BNB Chain testnet         | 97       |
-| Optimism testnet          | 420      |
-| Moonbase Alpha testnet    | 1287     |
-| Fantom testnet            | 4002     |
-| Avalanche Fuji testnet    | 43113    |
-| Polygon Mumbai testnet    | 80001    |
-| Milkomeda C1 testnet      | 200101   |
-| Arbitrum testnet          | 421613   |
-
 ### `airnode`
 
 <div style="word-wrap:break-word;margin-top:25px;">

--- a/docs/reference/qrng/providers.md
+++ b/docs/reference/qrng/providers.md
@@ -42,7 +42,7 @@ Australia. Visit their website at
 
 ANU Quantum Random Numbers are only available on
 [mainnets](/reference/qrng/chains.md#anu). For testnets use
-[Nodary](/reference/qrng/providers.md#nodary-pseudorandom-numbers).
+[Testnet Random Numbers](/reference/qrng/providers.md#testnet-random-numbers).
 [Quintessence](/reference/qrng/providers.md#quintessence-quantum-random-numbers)
 is available on mainnets and a few testnets.
 
@@ -78,13 +78,26 @@ is available on mainnets and a few testnets.
     <CopyIcon text="0x27cc2713e7f968e4e86ed274a051a5c8aaee9cca66946f23af6f29ecea9704c3"/>
 </div>
 
-## Nodary Pseudorandom Numbers
+## Testnet Random Numbers
 
-[**Nodary**<ExternalLinkImage/>](https://nodary.io/) is an independent group
-within the API3 ecosystem that builds high-impact oracle services. **Nodary**
-emulates QRNG using
+Testnet Random Numbers emulates QRNG using
 [pseudorandom numbers<ExternalLinkImage/>](https://www.mathworks.com/help/stats/generating-random-data.html)
-on [testnets](/reference/qrng/chains.md#nodary).
+on testnets to get familiar with QRNG.
+
+| Testnet                   | Chain Id |
+| --------------------------|----------|
+| Goerli                    | 5        |
+| Sepolia                   | 11155111 |
+| RSK testnet               | 31       |
+| POA Network Sokol testnet | 77       |
+| BNB Chain testnet         | 97       |
+| Optimism testnet          | 420      |
+| Moonbase Alpha testnet    | 1287     |
+| Fantom testnet            | 4002     |
+| Avalanche Fuji testnet    | 43113    |
+| Polygon Mumbai testnet    | 80001    |
+| Milkomeda C1 testnet      | 200101   |
+| Arbitrum testnet          | 421613   |
 
 ### `airnode`
 

--- a/docs/reference/qrng/providers.md
+++ b/docs/reference/qrng/providers.md
@@ -85,7 +85,7 @@ Testnet Random Numbers emulates QRNG using
 on testnets to get familiar with QRNG.
 
 | Testnet                   | Chain Id |
-| --------------------------|----------|
+| ------------------------- | -------- |
 | Goerli                    | 5        |
 | Sepolia                   | 11155111 |
 | RSK testnet               | 31       |


### PR DESCRIPTION
Since testnet random numbers are not operator by Nodary anymore, I updated the docs.