### PR TITLE
fix: clean up /dev code blocks

### DIFF
--- a/docs/dev/flexsearch.md
+++ b/docs/dev/flexsearch.md
@@ -71,8 +71,8 @@ indexes.
 
 Build the local data files via the Axios script.
 
-```js
-yarn axios:build;
+```sh
+yarn axios:build
 ```
 
 ### 2. Build the `/dist` folder
@@ -81,7 +81,7 @@ Build the `/dist` folder with the latest HTML files. All markdown files in
 `/docs` are converted to HTML files and are added to `/dist`. All files must
 contain the extraction markers `<Flex...Tag/>`.
 
-```js
+```sh
 yarn docs:build
 ```
 
@@ -89,11 +89,8 @@ yarn docs:build
 
 Builds the index files.
 
-```js
+```sh
 yarn flex:build
-
-// Runs the following from package.json
-// "flex:build": "node libs/flexBuildIndexes.js; yarn format;",
 ```
 
 Note the output from the command `yarn flex:build` which displays file sizes.
@@ -114,11 +111,8 @@ Check the size of the three `map.json` files which should be in the range of
 
 Test the index files.
 
-```js
+```sh
 yarn flex:test
-
-// Runs the following from package.json
-// "flex:test": "node libs/flexTestSearch.js;"
 ```
 
 ## Long strings warning

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -38,7 +38,6 @@ yarn install
 Create a working branch.
 
 ```sh
-// Create a working branch, with git or the VS Code UI
 git checkout -b <branch-name>
 ```
 
@@ -55,8 +54,11 @@ builds.
 
 ```sh
 yarn docs:build
+```
 
-// Output shown below
+The output should look like this:
+
+```sh
   vitepress v1.0.0-alpha.61
 
 ✓ building client + server bundles...
@@ -71,12 +73,11 @@ needed.
 ## Memory
 
 It maybe necessary to increase the memory for Nodejs to run `yarn docs:dev` or
-`yarn docs:build`. Make corrections as needed. For Apple silicon this may be a
-sign of a [Rosetta issue](/dev/rosetta.md) which should be addressed before
-committing to additional memory for Nodejs.
+`yarn docs:build`. This can be done with the command below, with a higher value
+potentially necessary. For Apple silicon this may be a sign of a
+[Rosetta issue](/dev/rosetta.md) which should be addressed before committing to
+additional memory for Nodejs.
 
 ```sh
-// If you get a memory error, change the memory space for Nodejs
-// usually 1024 or 2048 will work
 export NODE_OPTIONS=--max_old_space_size=1024
 ```

--- a/docs/dev/link-validation.md
+++ b/docs/dev/link-validation.md
@@ -40,8 +40,6 @@ The script must be run locally and will not work as a GitHub action.
 Build the docs as usual using the standard build command provided by VitePress.
 
 ```sh
-// From the vitepress-docs project root
-// Build the docs website
 yarn docs:build
 ```
 
@@ -54,13 +52,7 @@ VitePress has a built-in http server that publishes the files from the `/dist`
 folder.
 
 ```sh
-// Run from the root of vitepress-docs
 yarn docs:serve
-
-// Outputs
-  vitepress v1.0.0-x
-
-Built site served at http://localhost:8082/
 ```
 
 ### 3. Run the script
@@ -75,8 +67,5 @@ validation to a particular folder (docset) can hasten the validation process. Be
 sure to use the correct port displayed by VitePress server.
 
 ```sh
-# Open a new terminal window.
-# Run from the vitepress-docs project root.
-# Start the nodejs script.
 node ./libs/link-validator.js  http://localhost:8082  ./docs/.vitepress/dist/
 ```

--- a/docs/dev/rosetta.md
+++ b/docs/dev/rosetta.md
@@ -30,7 +30,7 @@ file.
 
 :::
 
-```js
+```sh
 failed to load config from /Users/warren/DEV/vitepress-docs/docs/.vitepress/config.js
 build error:
  Error:
@@ -63,12 +63,12 @@ is not running under Rosetta, it will install for the proper platform.
 `esbuild` will not appear in `packages.json` under `devDependencies`, but it
 does update.
 
-```js
+```sh
 yarn install --dev esbuild
 ```
 
 Next run a VitePress build.
 
-```js
+```sh
 yarn docs:build
 ```


### PR DESCRIPTION
A number of code blocks within `/dev` have extraneous text and comments that interfere with copy and pasting commands. For example:

![image](https://github.com/api3dao/vitepress-docs/assets/13989647/df2f0af2-087f-433b-9c26-42bc5eabfaeb)

When clicking the copy button, all of the ` // comments` will be copied and if pasted into the terminal, will be run, which results in a mess. I don't think any of the comments offer critical information. For example, the default is to run `yarn` commands from the project root.