### PR TITLE
fix: Remix IDE imports for guides

### DIFF
--- a/docs/guides/airnode/calling-an-airnode/index.md
+++ b/docs/guides/airnode/calling-an-airnode/index.md
@@ -44,14 +44,14 @@ Given below is an example of a basic
 data from any Airnode. To follow along, you can open the following contract in
 Remix and try deploying your own Requester Contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://github.com/vanshwassan/RemixContracts/blob/master/contracts/RequesterWithWithdrawal.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js&lang=en)
+[Open in Remix](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js&lang=en)
 
 ```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 
 // A Requester that will return the requested data by calling the specified Airnode.
 contract Requester is RrpRequesterV0, Ownable {

--- a/docs/guides/airnode/calling-an-airnode/index.md
+++ b/docs/guides/airnode/calling-an-airnode/index.md
@@ -44,7 +44,7 @@ Given below is an example of a basic
 data from any Airnode. To follow along, you can open the following contract in
 Remix and try deploying your own Requester Contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js&lang=en)
+[Open in Remix](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol)
 
 ```solidity
 // SPDX-License-Identifier: MIT

--- a/docs/guides/airnode/calling-an-airnode/index.md
+++ b/docs/guides/airnode/calling-an-airnode/index.md
@@ -44,7 +44,7 @@ Given below is an example of a basic
 data from any Airnode. To follow along, you can open the following contract in
 Remix and try deploying your own Requester Contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol)
+[Open in Remix](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -209,7 +209,7 @@ be calling the Coingecko Airnode to request the latest price of Ethereum.
 
 ### Compile and Deploy the Requester Contract on Goerli Testnet
 
-- [Click here](https://remix.ethereum.org/#url=https://github.com/vanshwassan/RemixContracts/blob/master/contracts/RequesterWithWithdrawal.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js&lang=en)
+- [Click here](https://remix.ethereum.org/#url=https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/RequesterWithWithdrawal.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
   to open the Requester Contract in Remix.
 
 > ![Opening the Requester Contract in Remix](src/s1.png)

--- a/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
+++ b/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
@@ -38,13 +38,13 @@ of manually funding each dAPI at regular intervals, you can use Gelato to
 automate the process.
 
 The following contract will be used in this guide. Open it in
-[Remix](https://remix.ethereum.org/#url=https://gist.githubusercontent.com/Ashar2shahid/a63d5b04ff9640c2f860f54dffa78995/raw/ce0a9461b817f59774deb1aaaa368438e4e3328b/Automation.sol).
+[Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Automation.sol).
 
 ```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.9;
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 import "https://github.com/gelatodigital/automate/blob/master/contracts/integrations/AutomateReady.sol";
 
 

--- a/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
+++ b/docs/guides/dapis/funding-multiple-dapis-gelato/index.md
@@ -38,7 +38,7 @@ of manually funding each dAPI at regular intervals, you can use Gelato to
 automate the process.
 
 The following contract will be used in this guide. Open it in
-[Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Automation.sol).
+[Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Automation.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.22+commit.4fc1097e.js).
 
 ```solidity
 // SPDX-License-Identifier: MIT

--- a/docs/guides/dapis/index.md
+++ b/docs/guides/dapis/index.md
@@ -93,7 +93,7 @@ call the `read()` function. Here's an example:
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 import "@api3/contracts/v0.8/interfaces/IProxy.sol";
 
 contract DataFeedReaderExample is Ownable {

--- a/docs/guides/dapis/read-a-dapi/index.md
+++ b/docs/guides/dapis/read-a-dapi/index.md
@@ -56,7 +56,7 @@ you.
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 import "@api3/contracts/v0.8/interfaces/IProxy.sol";
 
 contract DataFeedReaderExample is Ownable {

--- a/docs/guides/qrng/lottery-guide/index.md
+++ b/docs/guides/qrng/lottery-guide/index.md
@@ -54,7 +54,7 @@ you have added Metamask support to. Not all browsers support
 
 It should load up the `Lottery` contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Lottery.sol)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Lottery.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.22+commit.4fc1097e.js)
 
 ![Add Contract](/guides/qrng/lottery-guide/src/lottery1.png)
 
@@ -230,7 +230,7 @@ Airnode to request a random number.
 
 ### Compile and Deploy the Lottery Contract on Goerli Testnet
 
-- [Click here](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/camronh/Lottery-Tutorial/main/contracts/Lottery.sol)
+- [Click here](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Lottery.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.22+commit.4fc1097e.js)
   to open the Lottery Contract in Remix.
 
   ![Opening the Requester Contract in Remix](src/s1.png)

--- a/docs/guides/qrng/lottery-guide/index.md
+++ b/docs/guides/qrng/lottery-guide/index.md
@@ -54,7 +54,7 @@ you have added Metamask support to. Not all browsers support
 
 It should load up the `Lottery` contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/camronh/Lottery-Tutorial/main/contracts/Lottery.sol)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Lottery.sol)
 
 ![Add Contract](/guides/qrng/lottery-guide/src/lottery1.png)
 

--- a/docs/guides/qrng/qrng-remix/index.md
+++ b/docs/guides/qrng/qrng-remix/index.md
@@ -70,17 +70,19 @@ Airnode. To follow along, you can open the following contract in Remix and try
 deploying it yourself. This contract will be requesting the random number
 directly from the QRNG Provider.
 
+Head over to Remix IDE
+
 Head on to
-[Remix online IDE.](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.18+commit.87f61d96.js)
+[Remix online IDE.](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
 It should load up the `RemixQrngExample` contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.18+commit.87f61d96.js)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
 
 ```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.9;
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 
 /// @title Example contract that uses Airnode RRP to access QRNG services
 contract QrngExample is RrpRequesterV0, Ownable {

--- a/docs/guides/qrng/qrng-remix/index.md
+++ b/docs/guides/qrng/qrng-remix/index.md
@@ -70,7 +70,7 @@ Airnode. To follow along, you can open the following contract in Remix and try
 deploying it yourself. This contract will be requesting the random number
 directly from the QRNG Provider.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
 
 ```solidity
 //SPDX-License-Identifier: MIT

--- a/docs/guides/qrng/qrng-remix/index.md
+++ b/docs/guides/qrng/qrng-remix/index.md
@@ -70,13 +70,7 @@ Airnode. To follow along, you can open the following contract in Remix and try
 deploying it yourself. This contract will be requesting the random number
 directly from the QRNG Provider.
 
-Head over to Remix IDE
-
-Head on to
-[Remix online IDE.](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
-It should load up the `RemixQrngExample` contract.
-
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/QrngRequesterUpdated.sol)
 
 ```solidity
 //SPDX-License-Identifier: MIT

--- a/docs/guides/qrng/quantumon/index.md
+++ b/docs/guides/qrng/quantumon/index.md
@@ -35,7 +35,8 @@ minting.
 To see how Quantumon works, you can visit the
 [Quantumon](https://quantumon.xyz/) website. It uses an ERC-721 standard
 contract and QRNG to mint random NFTs and distribute them.
-[Check out the code here](https://gist.github.com/Ashar2shahid/e7b70712f23dd33b556aa66a6d8788b4).
+
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Quantumon.sol).
 
 Start by specifying the license, solidity version, importing the necessary
 contracts and then creating the actual contract itself.
@@ -44,8 +45,8 @@ contracts and then creating the actual contract itself.
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.14;
 import "@api3/airnode-protocol/contracts/rrp/requesters/RrpRequesterV0.sol";
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts@4.9.5/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts@4.9.5/access/Ownable.sol";
 contract Quantumon is ERC721, RrpRequesterV0, Ownable {
 
 }
@@ -435,6 +436,6 @@ Monsters. You also learned how to request data from a QRNG Airnode and how to
 use the data to mint an NFT.
 
 See the source code for the
-[Quantumon contract ](https://gist.github.com/Ashar2shahid/e7b70712f23dd33b556aa66a6d8788b4).
+[Quantumon contract ](https://github.com/api3-ecosystem/remix-contracts/blob/master/contracts/Quantumon.sol).
 
 <FlexEndTag/>

--- a/docs/guides/qrng/quantumon/index.md
+++ b/docs/guides/qrng/quantumon/index.md
@@ -36,7 +36,7 @@ To see how Quantumon works, you can visit the
 [Quantumon](https://quantumon.xyz/) website. It uses an ERC-721 standard
 contract and QRNG to mint random NFTs and distribute them.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Quantumon.sol).
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Quantumon.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.14+commit.80d49f37.js).
 
 Start by specifying the license, solidity version, importing the necessary
 contracts and then creating the actual contract itself.

--- a/docs/guides/qrng/roulette-guide/index.md
+++ b/docs/guides/qrng/roulette-guide/index.md
@@ -74,7 +74,7 @@ you have added Metamask support to. Not all browsers support
 
 It should load up the Roulette contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Roulette.sol)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Roulette.sol&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.22+commit.4fc1097e.js)
 
 > ![Remix 1](/guides/qrng/roulette-guide/src/SS1.png)
 

--- a/docs/guides/qrng/roulette-guide/index.md
+++ b/docs/guides/qrng/roulette-guide/index.md
@@ -74,7 +74,7 @@ you have added Metamask support to. Not all browsers support
 
 It should load up the Roulette contract.
 
-[Open in Remix](https://remix.ethereum.org/#url=https://github.com/Ashar2shahid/qrng-roulette/blob/main/contracts/contracts/Roulette.sol&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.9+commit.e5eed63a.js)
+[Open in Remix](https://remix.ethereum.org/#url=https://raw.githubusercontent.com/api3-ecosystem/remix-contracts/master/contracts/Roulette.sol)
 
 > ![Remix 1](/guides/qrng/roulette-guide/src/SS1.png)
 


### PR DESCRIPTION
It turns out changing the `@openzeppelin/contracts` version to `v4.9.5` works just fine. Updated the imports for both [API3 Ecosystem repo](https://github.com/api3-ecosystem/remix-contracts) and contracts within the guides.
Closes #693. 