### PR TITLE
Adjust renovate update settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
       "enabled": false
     },
     {
+      "matchPackageNames": ["vitepress"],
+      "groupName": "vitepress"
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
@@ -24,5 +28,6 @@
     "enabled": false
   },
   "reviewers": ["dcroote", "wkande"],
+  "minimumReleaseAge": "5 days",
   "dependencyDashboard": false
 }


### PR DESCRIPTION
- Separate vitepress from other updates
- Use a 5 day minimum package age

based on this comment: https://github.com/api3dao/vitepress-docs/pull/744#issuecomment-2148185589