### PR TITLE
Exclude vitepress from regular renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,12 +12,14 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
+      "excludePackageNames": ["vitepress"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dev-dependencies"
     },
     {
       "matchDepTypes": ["dependencies"],
+      "excludePackageNames": ["vitepress"],
       "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["before 4am on Monday"],
       "groupName": "non-major-dependencies"


### PR DESCRIPTION
Attempt number two to accomplish having `vitepress` updates in their own PRs (https://github.com/api3dao/vitepress-docs/pull/744#issuecomment-2148185589)