### PR TITLE
fix: default needed for v5 of html-dom-parser

### DIFF
--- a/libs/flexBuildIndexes.js
+++ b/libs/flexBuildIndexes.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 var file = require('file');
 const fse = require('fs-extra');
 const { Index } = require('flexsearch');
-const parse = require('html-dom-parser');
+const parse = require('html-dom-parser').default;
 
 let directoriesArr = [];
 let id = 1; // Used as the id for each page added to the index


### PR DESCRIPTION
v5 of `html-dom-parser` introduced a breaking change requiring the `.default` key: https://github.com/remarkablemark/html-dom-parser/blob/HEAD/CHANGELOG.md#-breaking-changes

This wasn't caught in #739 and the flex index build broke [per this comment](https://github.com/api3dao/vitepress-docs/pull/755#pullrequestreview-2109089648).