### PR TITLE
Fix OEV links

### DIFF
--- a/docs/reference/oev-network/dapps/index.md
+++ b/docs/reference/oev-network/dapps/index.md
@@ -37,8 +37,7 @@ market.
 </div>
 
 Searchers use signed data from Airnodes to update the proxy contract with the
-latest data point. However, if
-[`Api3ServerV1`](https://docs.api3.org/reference/dapis/understand/read-dapis.htmls)
+latest data point. However, if [`Api3ServerV1`](/reference/dapis/understand/)
 has a more recent timestamp than the last searcher update, the data point from
 `Api3ServerV1` will be displayed.
 
@@ -46,7 +45,7 @@ has a more recent timestamp than the last searcher update, the data point from
 
 Please refer to the following guide on how to read from a proxy contract:
 
-- [Reading a dAPI Proxy](https://docs.api3.org/guides/dapis/read-a-dapi/)
+- [Reading a dAPI Proxy](/guides/dapis/read-a-dapi/)
 
 :::
 

--- a/docs/reference/oev-network/overview/auction-cycle.md
+++ b/docs/reference/oev-network/overview/auction-cycle.md
@@ -94,7 +94,7 @@ met.
 If there are multiple bids that are satisfied, the auctioneer finds the winning
 bid by selecting the one with the highest bid amount. More details on how the
 auctioneer selects the winning bid can be found in the
-[Understanding Auctioneer](/reference/oev-network/searchers/understanding-auctioneer.html#parallel-auctions)
+[Understanding Auctioneer](/reference/oev-network/searchers/understanding-auctioneer.md#parallel-auctions)
 page.
 
 8. <b> Sign the winning bid</b>

--- a/docs/reference/oev-network/searchers/submit-bids.md
+++ b/docs/reference/oev-network/searchers/submit-bids.md
@@ -27,8 +27,8 @@ awarded bid and then finally submit fulfillment of the oracle update.
 
 ## Prerequisites
 
-- [Bridge ETH](/reference/oev-network/overview/bridge-oev-network.html) to the
-  OEV Network
+- [Bridge ETH](/reference/oev-network/overview/bridge-oev-network.md) to the OEV
+  Network
 
 - Clone the repository and install the dependencies
 
@@ -312,8 +312,8 @@ const awardedTransaction = await new Promise(async (resolve, reject) => {
 
 Once the bid is awarded, the searcher can perform the oracle update by using the
 encoded award transaction on the `updateOevProxyDataFeedWithSignedData` function
-of [Api3ServerV1 contract](https://docs.api3.org/reference/dapis/chains/) via
-the deployed OevSearcherMulticallV1 contract.
+of [Api3ServerV1 contract](/reference/dapis/chains/) via the deployed
+OevSearcherMulticallV1 contract.
 
 ```javascript
 const performOevUpdate = async (awardedTransaction) => {

--- a/docs/reference/oev-network/searchers/understanding-auctioneer.md
+++ b/docs/reference/oev-network/searchers/understanding-auctioneer.md
@@ -59,8 +59,8 @@ on the [API3 Market](https://market.api3.org/).
 
 For each proxy there is a separate auction round that takes place. The auction
 round is documented in the
-[Auction Cycle](/reference/oev-network/overview/auction-cycle.html) page but
-there are some nuances in the auctioneer state that are noted here.
+[Auction Cycle](/reference/oev-network/overview/auction-cycle.md) page but there
+are some nuances in the auctioneer state that are noted here.
 
 For each proxy the following checks are done by auctioneer during an auction
 round to filter out non-qualifying bids:


### PR DESCRIPTION
The first link was broken- the others are either 1) changed from external to internal or 2) changed from `.html` to `.md` (makes it amenable to link checking and navigation in an IDE).