### PR TITLE
fix: add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 /.vscode
 /node_modules
 /archives
+pnpm-lock.yaml
 
 # .vitepress
 /docs/.vitepress/cache


### PR DESCRIPTION
Closes the spurious PRs created when `pnpm format` (ran as part of `pnpm axios:build`) causes the `pnpm-lock.yaml` file to be formatted by prettier e.g. [here](https://github.com/api3dao/vitepress-docs/pull/800#issuecomment-2285162574).