### PR TITLE
fix: wrong character in code block styling

### DIFF
--- a/docs/_components/EthersAbiCoder.vue
+++ b/docs/_components/EthersAbiCoder.vue
@@ -17,7 +17,7 @@
         />
         <br />
         <div v-if="result">
-          <code style="text-align: left:">{{ result }}</code>
+          <code style="text-align: left">{{ result }}</code>
         </div>
       </form>
     </div>


### PR DESCRIPTION
I was looking at this component for other PRs and prettier flagged that there was an erroneous colon (probably was supposed to be a semicolon) but since there is only one style being applied prettier removed the character.